### PR TITLE
The volume.cfg still exists when volume deletion is incomplete

### DIFF
--- a/backupstore.go
+++ b/backupstore.go
@@ -74,9 +74,19 @@ func removeVolume(volumeName string, driver BackupStoreDriver) error {
 	}
 
 	volumeDir := getVolumePath(volumeName)
-	if err := driver.Remove(volumeDir); err != nil {
-		return err
+	volumeBlocksDirectory := getBlockPath(volumeName)
+	volumeBackupsDirectory := getBackupPath(volumeName)
+
+	if err := driver.Remove(volumeBackupsDirectory); err != nil {
+		return fmt.Errorf("failed to remove all the backups for volume %v", volumeName)
 	}
+	if err := driver.Remove(volumeBlocksDirectory); err != nil {
+		return fmt.Errorf("failed to remove all the blocks for volume %v", volumeName)
+	}
+	if err := driver.Remove(volumeDir); err != nil {
+		return fmt.Errorf("failed to remove backup volume %v directory in backupstore", volumeName)
+	}
+
 	log.Debug("Removed volume directory in backupstore: ", volumeDir)
 	log.Debug("Removed backupstore volume ", volumeName)
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/urfave/cli"
 
 	"github.com/longhorn/backupstore"
@@ -11,8 +12,14 @@ func BackupRemoveCmd() cli.Command {
 	return cli.Command{
 		Name:    "remove",
 		Aliases: []string{"rm", "delete"},
-		Usage:   "remove a backup in objectstore: rm <backup>",
-		Action:  cmdBackupRemove,
+		Usage:   "remove a backup or backup volume in objectstore: rm <backup>",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "volume",
+				Usage: "volume name, only use it when deleting a backup volume with dest URL",
+			},
+		},
+		Action: cmdBackupRemove,
 	}
 }
 
@@ -24,16 +31,26 @@ func cmdBackupRemove(c *cli.Context) {
 
 func doBackupRemove(c *cli.Context) error {
 	if c.NArg() == 0 {
-		return RequiredMissingError("backup URL")
+		return RequiredMissingError("dest URL")
 	}
-	backupURL := c.Args()[0]
-	if backupURL == "" {
-		return RequiredMissingError("backup URL")
+	destURL := c.Args()[0]
+	if destURL == "" {
+		return RequiredMissingError("dest URL")
 	}
-	backupURL = util.UnescapeURL(backupURL)
 
-	if err := backupstore.DeleteDeltaBlockBackup(backupURL); err != nil {
-		return err
+	volumeName := c.String("volume")
+	if volumeName == "" {
+		destURL = util.UnescapeURL(destURL)
+		if err := backupstore.DeleteDeltaBlockBackup(destURL); err != nil {
+			return err
+		}
+	} else {
+		if !util.ValidateName(volumeName) {
+			return fmt.Errorf("invalid backup volume name %v", volumeName)
+		}
+		if err := backupstore.DeleteBackupVolume(volumeName, destURL); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	"github.com/longhorn/backupstore/util"
+	"github.com/sirupsen/logrus"
 
 	. "github.com/longhorn/backupstore/logging"
 )

--- a/deltablock.go
+++ b/deltablock.go
@@ -499,6 +499,17 @@ func fillBlockToFile(block *[]byte, volDev *os.File, offset int64) error {
 	return nil
 }
 
+func DeleteBackupVolume(volumeName string, destURL string) error {
+	bsDriver, err := GetBackupStoreDriver(destURL)
+	if err != nil {
+		return err
+	}
+	if err := removeVolume(volumeName, bsDriver); err != nil {
+		return err
+	}
+	return nil
+}
+
 func DeleteDeltaBlockBackup(backupURL string) error {
 	bsDriver, err := GetBackupStoreDriver(backupURL)
 	if err != nil {


### PR DESCRIPTION
The volume.cfg now still exists when there is leftover in blocks in backupstore, as mentioned in https://github.com/longhorn/longhorn/issues/597