### PR TITLE
Revert "Remove json omitempty for Backups in VolumeInfo"

### DIFF
--- a/list.go
+++ b/list.go
@@ -16,7 +16,7 @@ type VolumeInfo struct {
 
 	Messages map[MessageType]string
 
-	Backups map[string]*BackupInfo
+	Backups map[string]*BackupInfo `json:",omitempty"`
 }
 
 type BackupInfo struct {


### PR DESCRIPTION
Reverts longhorn/backupstore#17

Cannot pass engine integration test.