### PR TITLE
Modifying CreateDeltaBlockBackup() to return backupType

### DIFF
--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -230,7 +230,7 @@ func (s *TestSuite) getDestURL() string {
 }
 
 func (s *TestSuite) createAndWaitForBackup(c *C, config *backupstore.DeltaBackupConfig, deltaOps *RawFileVolume) string {
-	_, err := backupstore.CreateDeltaBlockBackup(config)
+	_, _, err := backupstore.CreateDeltaBlockBackup(config)
 	c.Assert(err, IsNil)
 
 	retryCount := 120


### PR DESCRIPTION
The following code changes include modifying the CreateDeltaBlockBackup() to return the backuptype (isIncremental or not) along with the backupId.

Signed-off-by: Shreesha Rao <shreesha@rancher.com>

Issue: https://github.com/longhorn/longhorn/issues/592