### PR TITLE
nfs: Move the default mount directory out of `/var/lib/longhorn`

### DIFF
--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -28,7 +28,7 @@ const (
 	KIND = "nfs"
 
 	NfsPath  = "nfs.path"
-	MountDir = "/var/lib/longhorn/mounts"
+	MountDir = "/var/lib/longhorn-backupstore-mounts"
 
 	MaxCleanupLevel = 10
 )


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/1177

Otherwise it will accidentally propagate to the host when running inside
Longhorn manager

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>