### PR TITLE
Add support for using custom ca certificates for S3 backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# build files
+/.dapper
+
+# ignores all goland project folders and files
+.idea/
+*.iml
+*.ipr

--- a/deltablock.go
+++ b/deltablock.go
@@ -590,7 +590,7 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 
 	v, err := loadVolume(volumeName, bsDriver)
 	if err != nil {
-		return fmt.Errorf("Cannot find volume %v in backupstore", volumeName, err)
+		return fmt.Errorf("Cannot find volume %v in backupstore due to: %v", volumeName, err)
 	}
 
 	backup, err := loadBackup(backupName, volumeName, bsDriver)

--- a/driver.go
+++ b/driver.go
@@ -34,7 +34,7 @@ var (
 )
 
 func generateError(fields logrus.Fields, format string, v ...interface{}) error {
-	return ErrorWithFields("backupstore", fields, format, v)
+	return ErrorWithFields("backupstore", fields, format, v...)
 }
 
 func init() {

--- a/http/client.go
+++ b/http/client.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+)
+
+func getSystemCerts() *x509.CertPool {
+	certs, _ := x509.SystemCertPool()
+	if certs == nil {
+		certs = x509.NewCertPool()
+	}
+	return certs
+}
+
+// GetDefaultClient returns a client that does ssl verification based on the system certificates
+func GetDefaultClient() (*http.Client, error) {
+	return GetClient(false, nil)
+}
+
+func GetInsecureClient() (*http.Client, error) {
+	return GetClient(true, nil)
+}
+
+func GetClientWithCustomCerts(certs []byte) (*http.Client, error) {
+	return GetClient(true, certs)
+}
+
+func GetClient(insecure bool, customCerts []byte) (*http.Client, error) {
+	certs := getSystemCerts()
+
+	// CA's are base 64 encoded and appended together
+	// can contain root CAs, intermediate CAs and certificates
+	if ok := certs.AppendCertsFromPEM(customCerts); customCerts != nil && !ok {
+		return nil, fmt.Errorf("failed to append custom certificates: %v", string(customCerts))
+	}
+
+	// create custom http client that trusts our custom certs
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: insecure,
+		RootCAs:            certs,
+	}
+	client := &http.Client{Transport: customTransport}
+	return client, nil
+}

--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -14,6 +15,7 @@ import (
 type Service struct {
 	Region string
 	Bucket string
+	Client *http.Client
 }
 
 func (s *Service) New() (*s3.S3, error) {
@@ -24,7 +26,16 @@ func (s *Service) New() (*s3.S3, error) {
 		config.Endpoint = aws.String(endpoints)
 		config.S3ForcePathStyle = aws.Bool(true)
 	}
-	return s3.New(session.New(), config), nil
+
+	if s.Client != nil {
+		config.HTTPClient = s.Client
+	}
+
+	ses, err := session.NewSession(config)
+	if err != nil {
+		return nil, err
+	}
+	return s3.New(ses), nil
 }
 
 func (s *Service) Close() {

--- a/singlefile.go
+++ b/singlefile.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	"github.com/longhorn/backupstore/util"
+	"github.com/sirupsen/logrus"
 
 	. "github.com/longhorn/backupstore/logging"
 )
@@ -86,7 +86,7 @@ func RestoreSingleFileBackup(backupURL, path string) (string, error) {
 
 	if _, err := loadVolume(srcVolumeName, driver); err != nil {
 		return "", generateError(logrus.Fields{
-			LogFieldVolume:     srcVolumeName,
+			LogFieldVolume:    srcVolumeName,
 			LogEventBackupURL: backupURL,
 		}, "Volume doesn't exist in backupstore: %v", err)
 	}
@@ -117,7 +117,7 @@ func DeleteSingleFileBackup(backupURL string) error {
 
 	_, err = loadVolume(volumeName, driver)
 	if err != nil {
-		return fmt.Errorf("Cannot find volume %v in backupstore", volumeName, err)
+		return fmt.Errorf("Cannot find volume %v in backupstore due to: %v", volumeName, err)
 	}
 
 	backup, err := loadBackup(backupName, volumeName, driver)


### PR DESCRIPTION
The custom ssl cert will be loaded from `AWS_CERT` if present and used together with the default system certificates for the s3 service client

This is to address longhorn/longhorn#704