### PR TITLE
Fix backupstore incremental backup logic

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -12,6 +12,9 @@ const (
 	LogFieldVolumeName   = "volume_name"
 	LogFieldOrigVolume   = "original_volume"
 	LogFieldSnapshot     = "snapshot"
+	LogFieldBackup       = "backup"
+	LogFieldBackupType   = "backup_type"
+	LogFieldLastBackup   = "last_backup"
 	LogFieldLastSnapshot = "last_snapshot"
 	LogEventBackupURL    = "backup_url"
 	LogFieldDestURL      = "dest_url"
@@ -30,6 +33,7 @@ const (
 	LogReasonFallback = "fallback"
 
 	LogFieldObject    = "object"
+	LogObjectBackup   = "backup"
 	LogObjectSnapshot = "snapshot"
 	LogObjectConfig   = "config"
 )


### PR DESCRIPTION
We always merged the blocks from the new and previous backup on the
backupstore if the previous backup was present even in the case of a non
incremental backup.

longhorn/longhorn#1294

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
