### PR TITLE
Ignore invalid backups during backup listing

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -23,6 +23,7 @@ const (
 
 	LogFieldEvent        = "event"
 	LogEventBackup       = "backup"
+	LogEventList         = "list"
 	LogEventRestore      = "restore"
 	LogEventRestoreIncre = "restore_incrementally"
 	LogEventCompare      = "compare"

--- a/util/util.go
+++ b/util/util.go
@@ -76,6 +76,12 @@ func ExtractNames(names []string, prefix, suffix string) ([]string, error) {
 		f := names[i]
 		// Remove additional slash if exists
 		f = strings.TrimLeft(f, "/")
+
+		// Not a backup config file
+		if !strings.HasPrefix(f, prefix) || !strings.HasSuffix(f, suffix) {
+			continue
+		}
+
 		f = strings.TrimPrefix(f, prefix)
 		f = strings.TrimSuffix(f, suffix)
 		if !ValidateName(f) {


### PR DESCRIPTION
Signal invalid backups for backup list operation

Any backup.cfg loading error during a list operation will now be 
signaled as part of the returned BackupInfo.Messages field

longhorn/longhorn#1212

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
