### PR TITLE
Reduce concurrency issues for backup operations

### DIFF
--- a/list.go
+++ b/list.go
@@ -78,6 +78,9 @@ func addListVolume(volumeName string, driver BackupStoreDriver, volumeOnly bool)
 				LogFieldVolume: volumeName,
 			}).Warn("Failed to load backup in backupstore")
 			info = failedBackupInfo(backupName, volumeName, driver.GetURL(), err)
+		} else if isBackupInProgress(backup) {
+			// for now we don't return in progress backups to the ui
+			continue
 		} else {
 			info = fillBackupInfo(backup, driver.GetURL())
 		}
@@ -178,6 +181,10 @@ func InspectBackup(backupURL string) (*BackupInfo, error) {
 			LogFieldVolume: volumeName,
 		}).Info("Failed to load backup in backupstore")
 		return nil, err
+	} else if isBackupInProgress(backup) {
+		// for now we don't return in progress backups to the ui
+		return nil, fmt.Errorf("backup %v is still in progress", backup.Name)
 	}
+
 	return fillFullBackupInfo(backup, volume, driver.GetURL()), nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -70,6 +70,22 @@ func Now() string {
 	return time.Now().UTC().Format(time.RFC3339)
 }
 
+func UnorderedEqual(x, y []string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	known := make(map[string]struct{})
+	for _, value := range x {
+		known[value] = struct{}{}
+	}
+	for _, value := range y {
+		if _, present := known[value]; !present {
+			return false
+		}
+	}
+	return true
+}
+
 func ExtractNames(names []string, prefix, suffix string) ([]string, error) {
 	result := []string{}
 	for i := range names {


### PR DESCRIPTION
When starting a backup after checking all preconditions we create a
backup metadata file that only contains the backup name as well as an
empty creation time which we use as an in progress marker. We currently
do not return these backups to the ui.

For nfs we now always create a tmp file with the current nano timestamp
appended so that 2 backup operations can never operate on the same tmp
file. We also do not remove these explicitly instead we rely on the
rename sys call to flip over the tmp file to the desired destination
file.

We now also also have a check to see if there have been any changes on
the known backups since we started the garbage collection process.
This will lead to skipping the block deletion if we detect changes on
the backup count.

I also removed the Volume deletion as part of the Backup deletion call.
Since we have a dedicated call for volume deletion, we should only ever
delete the whole volume if it actually is requested by the caller via
the dedicated volume deletion call.

longhorn/longhorn#1341
longhorn/longhorn#1326

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
