### PR TITLE
Fix in progress backups did not include the volume name

### DIFF
--- a/config.go
+++ b/config.go
@@ -178,6 +178,9 @@ func loadBackup(backupName, volumeName string, bsDriver BackupStoreDriver) (*Bac
 }
 
 func saveBackup(backup *Backup, bsDriver BackupStoreDriver) error {
+	if backup.VolumeName == "" {
+		return fmt.Errorf("missing volume specifier for backup: %v", backup.Name)
+	}
 	filePath := getBackupConfigPath(backup.Name, backup.VolumeName)
 	if err := saveConfigInBackupStore(filePath, bsDriver, backup); err != nil {
 		return err

--- a/deltablock.go
+++ b/deltablock.go
@@ -199,7 +199,8 @@ func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Back
 	bsDriver BackupStoreDriver) (int, string, error) {
 
 	// create an in progress backup metadata file
-	if err := saveBackup(&Backup{Name: deltaBackup.Name, CreatedTime: ""}, bsDriver); err != nil {
+	if err := saveBackup(&Backup{Name: deltaBackup.Name, VolumeName: deltaBackup.VolumeName,
+		CreatedTime: ""}, bsDriver); err != nil {
 		return 0, "", err
 	}
 


### PR DESCRIPTION
Also added a test in saveBackup to make sure that there is always a
volume specified. Otherwise we end up creating the backup in the wrong
location.

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
