### PR TITLE
Fix backupstore list issues

### DIFF
--- a/config.go
+++ b/config.go
@@ -88,7 +88,7 @@ func getVolumePath(volumeName string) string {
 	checksum := util.GetChecksum([]byte(volumeName))
 	volumeLayer1 := checksum[0:VOLUME_SEPARATE_LAYER1]
 	volumeLayer2 := checksum[VOLUME_SEPARATE_LAYER1:VOLUME_SEPARATE_LAYER2]
-	return filepath.Join(backupstoreBase, VOLUME_DIRECTORY, volumeLayer1, volumeLayer2, volumeName)
+	return filepath.Join(backupstoreBase, VOLUME_DIRECTORY, volumeLayer1, volumeLayer2, volumeName) + "/"
 }
 
 func getVolumeFilePath(volumeName string) string {

--- a/list.go
+++ b/list.go
@@ -47,11 +47,6 @@ func addListVolume(volumeName string, driver BackupStoreDriver, volumeOnly bool)
 		return nil, fmt.Errorf("Invalid volume name %v", volumeName)
 	}
 
-	backupNames, err := getBackupNamesForVolume(volumeName, driver)
-	if err != nil {
-		return nil, err
-	}
-
 	volume, err := loadVolume(volumeName, driver)
 	if err != nil {
 		return &VolumeInfo{
@@ -63,6 +58,13 @@ func addListVolume(volumeName string, driver BackupStoreDriver, volumeOnly bool)
 
 	volumeInfo := fillVolumeInfo(volume)
 	if volumeOnly {
+		return volumeInfo, nil
+	}
+
+	// try to find all backups for this volume
+	backupNames, err := getBackupNamesForVolume(volumeName, driver)
+	if err != nil {
+		volumeInfo.Messages[MessageTypeError] = err.Error()
 		return volumeInfo, nil
 	}
 

--- a/list.go
+++ b/list.go
@@ -131,9 +131,10 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 func failedBackupInfo(backupName string, volumeName string,
 	destURL string, err error) *BackupInfo {
 	return &BackupInfo{
-		Name:     backupName,
-		URL:      encodeBackupURL(backupName, volumeName, destURL),
-		Messages: map[MessageType]string{MessageTypeError: err.Error()},
+		Name:       backupName,
+		URL:        encodeBackupURL(backupName, volumeName, destURL),
+		VolumeName: volumeName,
+		Messages:   map[MessageType]string{MessageTypeError: err.Error()},
 	}
 }
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -115,6 +115,10 @@ func (s *TestSuite) TestExtractNames(c *C) {
 	files[0] = "prefix__dd_xx.suffix"
 	result, err = ExtractNames(files, "prefix_", ".suffix")
 	c.Assert(err, ErrorMatches, "Invalid name.*")
+
+	files[0] = "backup_1234@failure.cfg"
+	result, err = ExtractNames(files, "backup_", ".cfg")
+	c.Assert(err, ErrorMatches, "Invalid name.*")
 }
 
 func (s *TestSuite) TestValidateName(c *C) {


### PR DESCRIPTION
Previously when loading the backup names error we would return an error for the whole list call, instead, we should return volume info with an error set.

This way an issue on one volume cannot block the whole backup list from showing up.

longhorn/longhorn#1410