### PR TITLE
Ignore invalid named files instead of failing

### DIFF
--- a/config.go
+++ b/config.go
@@ -148,7 +148,7 @@ func getBackupNamesForVolume(volumeName string, driver BackupStoreDriver) ([]str
 		// path doesn't exist
 		return result, nil
 	}
-	return util.ExtractNames(fileList, BACKUP_CONFIG_PREFIX, CFG_SUFFIX)
+	return util.ExtractNames(fileList, BACKUP_CONFIG_PREFIX, CFG_SUFFIX), nil
 }
 
 func getBackupPath(volumeName string) string {

--- a/deltablock.go
+++ b/deltablock.go
@@ -817,7 +817,7 @@ func getBlockNamesForVolume(volumeName string, driver BackupStoreDriver) ([]stri
 		}
 	}
 
-	return util.ExtractNames(names, "", BLK_SUFFIX)
+	return util.ExtractNames(names, "", BLK_SUFFIX), nil
 }
 
 func getBlockPath(volumeName string) string {

--- a/util/util.go
+++ b/util/util.go
@@ -96,14 +96,13 @@ func Filter(elements []string, predicate func(string) bool) []string {
 	return filtered
 }
 
-func ExtractNames(names []string, prefix, suffix string) ([]string, error) {
+func ExtractNames(names []string, prefix, suffix string) []string {
 	result := []string{}
-	for i := range names {
-		f := names[i]
+	for _, f := range names {
 		// Remove additional slash if exists
 		f = strings.TrimLeft(f, "/")
 
-		// Not a backup config file
+		// missing prefix or suffix
 		if !strings.HasPrefix(f, prefix) || !strings.HasSuffix(f, suffix) {
 			continue
 		}
@@ -111,11 +110,13 @@ func ExtractNames(names []string, prefix, suffix string) ([]string, error) {
 		f = strings.TrimPrefix(f, prefix)
 		f = strings.TrimSuffix(f, suffix)
 		if !ValidateName(f) {
-			return nil, fmt.Errorf("Invalid name %v was processed to extract name with prefix %v surfix %v", names[i], prefix, suffix)
+			logrus.Errorf("Invalid name %v was processed to extract name with prefix %v suffix %v",
+				f, prefix, suffix)
+			continue
 		}
 		result = append(result, f)
 	}
-	return result, nil
+	return result
 }
 
 func ValidateName(name string) bool {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -93,32 +93,34 @@ func (s *TestSuite) TestExtractNames(c *C) {
 		files[i] = prefix + names[i] + suffix
 	}
 
-	result, err := ExtractNames(files, "prefix_", ".suffix")
-	c.Assert(err, Equals, nil)
+	result := ExtractNames(files, "prefix_", ".suffix")
 	for i := 0; i < counts; i++ {
 		c.Assert(result[i], Equals, names[i])
 	}
 
 	files[0] = "/" + files[0]
-	result, err = ExtractNames(files, "prefix_", ".suffix")
-	c.Assert(err, Equals, nil)
+	result = ExtractNames(files, "prefix_", ".suffix")
 	c.Assert(result[0], Equals, names[0])
 
 	files[0] = "prefix_.dd_xx.suffix"
-	result, err = ExtractNames(files, "prefix_", ".suffix")
-	c.Assert(err, ErrorMatches, "Invalid name.*")
+	result = ExtractNames(files, "prefix_", ".suffix")
+	c.Assert(len(result), Equals, len(files)-1)
+	c.Assert(result[0], Equals, names[1]) // files[0] is invalid
 
 	files[0] = "prefix_-dd_xx.suffix"
-	result, err = ExtractNames(files, "prefix_", ".suffix")
-	c.Assert(err, ErrorMatches, "Invalid name.*")
+	result = ExtractNames(files, "prefix_", ".suffix")
+	c.Assert(len(result), Equals, len(files)-1)
+	c.Assert(result[0], Equals, names[1]) // files[0] is invalid
 
 	files[0] = "prefix__dd_xx.suffix"
-	result, err = ExtractNames(files, "prefix_", ".suffix")
-	c.Assert(err, ErrorMatches, "Invalid name.*")
+	result = ExtractNames(files, "prefix_", ".suffix")
+	c.Assert(len(result), Equals, len(files)-1)
+	c.Assert(result[0], Equals, names[1]) // files[0] is invalid
 
-	files[0] = "backup_1234@failure.cfg"
-	result, err = ExtractNames(files, "backup_", ".cfg")
-	c.Assert(err, ErrorMatches, "Invalid name.*")
+	files[0] = "prefix_1234@failure.suffix"
+	result = ExtractNames(files, "prefix_", ".suffix")
+	c.Assert(len(result), Equals, len(files)-1)
+	c.Assert(result[0], Equals, names[1]) // files[0] is invalid
 }
 
 func (s *TestSuite) TestValidateName(c *C) {


### PR DESCRIPTION
A file that doesn't conform to our search target (regex) wouldn't have
been created by us, so there is no point in erroring or failing the list
operations, instead we just return a list of valid backup/block names.

longhorn/longhorn#1410

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
