### PR TITLE
Add file based locks for concurrent backupstore operations

### DIFF
--- a/backupstore.go
+++ b/backupstore.go
@@ -73,11 +73,15 @@ func removeVolume(volumeName string, driver BackupStoreDriver) error {
 	volumeDir := getVolumePath(volumeName)
 	volumeBlocksDirectory := getBlockPath(volumeName)
 	volumeBackupsDirectory := getBackupPath(volumeName)
+	volumeLocksDirectory := getLockPath(volumeName)
 	if err := driver.Remove(volumeBackupsDirectory); err != nil {
 		return fmt.Errorf("failed to remove all the backups for volume %v: %v", volumeName, err)
 	}
 	if err := driver.Remove(volumeBlocksDirectory); err != nil {
 		return fmt.Errorf("failed to remove all the blocks for volume %v: %v", volumeName, err)
+	}
+	if err := driver.Remove(volumeLocksDirectory); err != nil {
+		return fmt.Errorf("failed to remove all the locks for volume %v: %v", volumeName, err)
 	}
 	if err := driver.Remove(volumeDir); err != nil {
 		return fmt.Errorf("failed to remove backup volume %v directory in backupstore: %v", volumeName, err)

--- a/deltablock.go
+++ b/deltablock.go
@@ -116,6 +116,16 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 		return "", false, err
 	}
 
+	lock, err := New(bsDriver, volume.Name, BACKUP_LOCK)
+	if err != nil {
+		return "", false, err
+	}
+
+	defer lock.Unlock()
+	if err := lock.Lock(); err != nil {
+		return "", false, err
+	}
+
 	if err := addVolume(volume, bsDriver); err != nil {
 		return "", false, err
 	}
@@ -203,8 +213,15 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 		Blocks:       []BlockMapping{},
 	}
 
+	// keep lock alive for async go routine.
+	if err := lock.Lock(); err != nil {
+		deltaOps.CloseSnapshot(snapshot.Name, volume.Name)
+		return "", backupRequest.isIncrementalBackup(), err
+	}
 	go func() {
 		defer deltaOps.CloseSnapshot(snapshot.Name, volume.Name)
+		defer lock.Unlock()
+
 		if progress, backup, err := performBackup(config, delta, deltaBackup, backupRequest.lastBackup, bsDriver); err != nil {
 			deltaOps.UpdateBackupStatus(snapshot.Name, volume.Name, progress, "", err.Error())
 		} else {
@@ -381,6 +398,16 @@ func RestoreDeltaBlockBackup(config *DeltaRestoreConfig) error {
 		return err
 	}
 
+	lock, err := New(bsDriver, srcVolumeName, RESTORE_LOCK)
+	if err != nil {
+		return err
+	}
+
+	defer lock.Unlock()
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+
 	vol, err := loadVolume(srcVolumeName, bsDriver)
 	if err != nil {
 		return generateError(logrus.Fields{
@@ -404,6 +431,12 @@ func RestoreDeltaBlockBackup(config *DeltaRestoreConfig) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		// make sure to close the device
+		if err != nil {
+			_ = volDev.Close()
+		}
+	}()
 
 	stat, err := volDev.Stat()
 	if err != nil {
@@ -425,8 +458,14 @@ func RestoreDeltaBlockBackup(config *DeltaRestoreConfig) error {
 		LogEventBackupURL:  backupURL,
 	}).Debug()
 
+	// keep lock alive for async go routine.
+	if err := lock.Lock(); err != nil {
+		return err
+	}
 	go func() {
 		defer volDev.Close()
+		defer lock.Unlock()
+
 		blkCounts := len(backup.Blocks)
 		var progress int
 		for i, block := range backup.Blocks {
@@ -493,6 +532,16 @@ func RestoreDeltaBlockBackupIncrementally(config *DeltaRestoreConfig) error {
 		return err
 	}
 
+	lock, err := New(bsDriver, srcVolumeName, RESTORE_LOCK)
+	if err != nil {
+		return err
+	}
+
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+	defer lock.Unlock()
+
 	vol, err := loadVolume(srcVolumeName, bsDriver)
 	if err != nil {
 		return generateError(logrus.Fields{
@@ -522,6 +571,12 @@ func RestoreDeltaBlockBackupIncrementally(config *DeltaRestoreConfig) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		// make sure to close the device
+		if err != nil {
+			_ = volDev.Close()
+		}
+	}()
 
 	stat, err := volDev.Stat()
 	if err != nil {
@@ -546,8 +601,13 @@ func RestoreDeltaBlockBackupIncrementally(config *DeltaRestoreConfig) error {
 		LogFieldVolumeDev:  volDevName,
 		LogEventBackupURL:  backupURL,
 	}).Debugf("Started incrementally restoring from %v to %v", lastBackup, backup)
+	// keep lock alive for async go routine.
+	if err := lock.Lock(); err != nil {
+		return err
+	}
 	go func() {
 		defer volDev.Close()
+		defer lock.Unlock()
 
 		if err := performIncrementalRestore(srcVolumeName, volDev, lastBackup, backup, bsDriver, config); err != nil {
 			deltaOps.UpdateRestoreStatus(volDevName, 0, err)
@@ -630,6 +690,15 @@ func DeleteBackupVolume(volumeName string, destURL string) error {
 	if err != nil {
 		return err
 	}
+	lock, err := New(bsDriver, volumeName, DELETION_LOCK)
+	if err != nil {
+		return err
+	}
+
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+	defer lock.Unlock()
 	if err := removeVolume(volumeName, bsDriver); err != nil {
 		return err
 	}
@@ -711,6 +780,16 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 	if err != nil {
 		return err
 	}
+
+	lock, err := New(bsDriver, volumeName, DELETION_LOCK)
+	if err != nil {
+		return err
+	}
+
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+	defer lock.Unlock()
 
 	// If we fail to load the backup we still want to proceed with the deletion of the backup file
 	backupToBeDeleted, err := loadBackup(backupName, volumeName, bsDriver)

--- a/driver.go
+++ b/driver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -17,6 +18,7 @@ type BackupStoreDriver interface {
 	GetURL() string
 	FileExists(filePath string) bool
 	FileSize(filePath string) int64
+	FileTime(filePath string) time.Time
 	Remove(path string) error               // Bahavior like "rm -rf"
 	Read(src string) (io.ReadCloser, error) // Caller needs to close
 	Write(dst string, rs io.ReadSeeker) error

--- a/fsops/fsops.go
+++ b/fsops/fsops.go
@@ -44,6 +44,16 @@ func (f *FileSystemOperator) FileSize(filePath string) int64 {
 	return st.Size()
 }
 
+func (f *FileSystemOperator) FileTime(filePath string) time.Time {
+	file := f.LocalPath(filePath)
+	st, err := os.Stat(file)
+	if err != nil || st.IsDir() {
+		return time.Time{}
+	}
+
+	return st.ModTime()
+}
+
 func (f *FileSystemOperator) FileExists(filePath string) bool {
 	return f.FileSize(filePath) >= 0
 }

--- a/lock.go
+++ b/lock.go
@@ -1,0 +1,240 @@
+package backupstore
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/longhorn/backupstore/util"
+)
+
+const (
+	LOCKS_DIRECTORY       = "locks"
+	LOCK_PREFIX           = "lock"
+	LOCK_SUFFIX           = ".lck"
+	LOCK_DURATION         = time.Second * 150
+	LOCK_MAX_WAIT_TIME    = time.Second * 30
+	LOCK_REFRESH_INTERVAL = time.Second * 60
+	LOCK_CHECK_INTERVAL   = time.Second * 10
+	LOCK_CHECK_WAIT_TIME  = time.Second * 2
+)
+
+type LockType int
+
+const UNTYPED_LOCK LockType = 0
+const BACKUP_LOCK LockType = 1
+const RESTORE_LOCK LockType = 1
+const DELETION_LOCK LockType = 2
+
+type FileLock struct {
+	Name       string
+	Type       LockType
+	Acquired   bool
+	driver     BackupStoreDriver
+	volume     string
+	count      int32
+	serverTime time.Time
+	keepAlive  chan struct{}
+	mutex      sync.Mutex
+}
+
+func New(driver BackupStoreDriver, volumeName string, lockType LockType) (*FileLock, error) {
+	return &FileLock{driver: driver, volume: volumeName,
+		Type: lockType, Name: util.GenerateName(LOCK_PREFIX)}, nil
+}
+
+// isExpired checks whether the current lock is expired
+func (lock *FileLock) isExpired() bool {
+	isExpired := time.Now().Sub(lock.serverTime) > LOCK_DURATION
+	return isExpired
+}
+
+func (lock *FileLock) canAcquire() bool {
+	canAcquire := true
+	locks := getLocksForVolume(lock.volume, lock.driver)
+	for _, serverLock := range locks {
+		serverLockHasDifferentType := serverLock.Type != lock.Type
+		serverLockHasPriority := compareLocks(serverLock, lock) < 0
+		if serverLockHasDifferentType && serverLockHasPriority && !serverLock.isExpired() {
+			canAcquire = false
+			break
+		}
+	}
+
+	return canAcquire
+}
+
+func (lock *FileLock) Lock() error {
+	lock.mutex.Lock()
+	defer lock.mutex.Unlock()
+	if lock.Acquired {
+		atomic.AddInt32(&lock.count, 1)
+		_ = saveLock(lock)
+		return nil
+	}
+
+	// we create first then retrieve all locks
+	// because this way if another client creates at the same time
+	// one of us will be first in the times array
+	// the servers modification time is only the initial lock creation time
+	// and we do not need to start lock refreshing till after we acquired the lock
+	// since lock expiration is based on the serverTime + LOCK_MAX_WAIT_TIME
+	if err := saveLock(lock); err != nil {
+		return err
+	}
+
+	// since the node times might not be perfectly in sync and the servers file time has second precision
+	// we wait 2 seconds before retrieving the current set of locks, this eliminates a race condition
+	// where 2 processes request a lock at the same time
+	time.Sleep(LOCK_CHECK_WAIT_TIME)
+
+	for acquired := lock.Acquired; !acquired; acquired = lock.Acquired {
+		if lock.canAcquire() {
+			file := getLockFilePath(lock.volume, lock.Name)
+			log.Debugf("Acquired lock %v type %v on backupstore", file, lock.Type)
+			lock.Acquired = true
+			atomic.AddInt32(&lock.count, 1)
+			if err := saveLock(lock); err != nil {
+				_ = removeLock(lock)
+				return err
+			}
+
+			// enable lock refresh
+			lock.keepAlive = make(chan struct{})
+			go func() {
+				refreshTimer := time.NewTicker(LOCK_REFRESH_INTERVAL)
+				defer refreshTimer.Stop()
+				for {
+					select {
+					case <-lock.keepAlive:
+						return
+					case <-refreshTimer.C:
+						lock.mutex.Lock()
+						if lock.Acquired {
+							_ = saveLock(lock)
+						}
+						lock.mutex.Unlock()
+					}
+				}
+			}()
+			break
+		}
+
+		if timeout := time.Now().Sub(lock.serverTime) > LOCK_MAX_WAIT_TIME; timeout {
+			file := getLockFilePath(lock.volume, lock.Name)
+			_ = removeLock(lock)
+			return fmt.Errorf("failed lock %v type %v acquisition, exceeded maximum wait time %v",
+				file, lock.Type, LOCK_MAX_WAIT_TIME)
+		}
+
+		if !lock.Acquired {
+			time.Sleep(LOCK_CHECK_INTERVAL)
+		}
+	}
+
+	return nil
+}
+
+func (lock *FileLock) Unlock() error {
+	lock.mutex.Lock()
+	defer lock.mutex.Unlock()
+	if atomic.AddInt32(&lock.count, -1) <= 0 {
+		lock.Acquired = false
+		if lock.keepAlive != nil {
+			close(lock.keepAlive)
+		}
+		if err := removeLock(lock); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func loadLock(volumeName string, name string, driver BackupStoreDriver) (*FileLock, error) {
+	lock := &FileLock{}
+	file := getLockFilePath(volumeName, name)
+	if err := loadConfigInBackupStore(file, driver, lock); err != nil {
+		return nil, err
+	}
+	lock.serverTime = driver.FileTime(file)
+	log.Debugf("Loaded lock %v type %v on backupstore", file, lock.Type)
+	return lock, nil
+}
+
+func removeLock(lock *FileLock) error {
+	file := getLockFilePath(lock.volume, lock.Name)
+	if err := lock.driver.Remove(file); err != nil {
+		return err
+	}
+	log.Debugf("Removed lock %v type %v on backupstore", file, lock.Type)
+	return nil
+}
+
+func saveLock(lock *FileLock) error {
+	file := getLockFilePath(lock.volume, lock.Name)
+	if err := saveConfigInBackupStore(file, lock.driver, lock); err != nil {
+		return err
+	}
+	lock.serverTime = lock.driver.FileTime(file)
+	log.Debugf("Stored lock %v type %v on backupstore", file, lock.Type)
+	return nil
+}
+
+// compareLocks compares the locks by Acquired
+// then by serverTime followed by Name
+func compareLocks(a *FileLock, b *FileLock) int {
+	if a.Acquired == b.Acquired {
+		if a.serverTime.Equal(b.serverTime) {
+			return strings.Compare(a.Name, b.Name)
+		} else if a.serverTime.Before(b.serverTime) {
+			return -1
+		} else {
+			return 1
+		}
+	} else if a.Acquired {
+		return -1
+	} else {
+		return 1
+	}
+}
+
+func getLockNamesForVolume(volumeName string, driver BackupStoreDriver) []string {
+	fileList, err := driver.List(getLockPath(volumeName))
+	if err != nil {
+		// path doesn't exist
+		return []string{}
+	}
+	names := util.ExtractNames(fileList, "", LOCK_SUFFIX)
+	return names
+}
+
+func getLocksForVolume(volumeName string, driver BackupStoreDriver) []*FileLock {
+	fileList := getLockNamesForVolume(volumeName, driver)
+	locks := make([]*FileLock, 0, len(fileList))
+	for _, name := range fileList {
+		lock, err := loadLock(volumeName, name, driver)
+		if err != nil {
+			file := getLockFilePath(volumeName, name)
+			log.Warnf("failed to load lock %v on backupstore reason %v", file, err)
+			continue
+		}
+		locks = append(locks, lock)
+	}
+
+	return locks
+}
+
+func getLockPath(volumeName string) string {
+	return filepath.Join(getVolumePath(volumeName), LOCKS_DIRECTORY) + "/"
+}
+
+func getLockFilePath(volumeName string, name string) string {
+	path := getLockPath(volumeName)
+	fileName := name + LOCK_SUFFIX
+	return filepath.Join(path, fileName)
+}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/longhorn/backupstore"
 	"github.com/longhorn/backupstore/http"
 	"github.com/sirupsen/logrus"
@@ -146,13 +148,19 @@ func (s *BackupStoreDriver) FileExists(filePath string) bool {
 func (s *BackupStoreDriver) FileSize(filePath string) int64 {
 	path := s.updatePath(filePath)
 	head, err := s.service.HeadObject(path)
-	if err != nil {
-		return -1
-	}
-	if head.ContentLength == nil {
+	if err != nil || head.ContentLength == nil {
 		return -1
 	}
 	return *head.ContentLength
+}
+
+func (s *BackupStoreDriver) FileTime(filePath string) time.Time {
+	path := s.updatePath(filePath)
+	head, err := s.service.HeadObject(path)
+	if err != nil || head.ContentLength == nil {
+		return time.Time{}
+	}
+	return aws.TimeValue(head.LastModified)
 }
 
 func (s *BackupStoreDriver) Remove(path string) error {


### PR DESCRIPTION
We can only acquire a lock if there is no unexpired(1) lock of a different
type(2) that has priority(3).

1) Locks are self expiring, once the current time is after
`lock.serverTime + LOCK_MAX_WAIT_TIME` we no longer need to consider
this lock as valid.

2) Backup & Restore Locks are mapped to compatible types while Delete
Locks are mapped to a different type to be mutually exclusive with the
others.

3) Priority is based on the comparison order, where locks are compared by
`lock.Acquired` then by `lock.serverTime` followed by `lock.Name`. Where
acquired locks are always sorted before non acquired locks.

After 2 minutes, the lock acquisition will timeout and the backup
operation will pass through that error and fail.

longhorn/longhorn#612

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
