### PR TITLE
Remove retry mechanism for lock acquisition

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -18,7 +18,7 @@ type BackupStoreDriver interface {
 	GetURL() string
 	FileExists(filePath string) bool
 	FileSize(filePath string) int64
-	FileTime(filePath string) time.Time
+	FileTime(filePath string) time.Time     // Needs to be returned in UTC
 	Remove(path string) error               // Bahavior like "rm -rf"
 	Read(src string) (io.ReadCloser, error) // Caller needs to close
 	Write(dst string, rs io.ReadSeeker) error

--- a/fsops/fsops.go
+++ b/fsops/fsops.go
@@ -51,7 +51,7 @@ func (f *FileSystemOperator) FileTime(filePath string) time.Time {
 		return time.Time{}
 	}
 
-	return st.ModTime()
+	return st.ModTime().UTC()
 }
 
 func (f *FileSystemOperator) FileExists(filePath string) bool {
@@ -88,7 +88,7 @@ func (f *FileSystemOperator) Read(src string) (io.ReadCloser, error) {
 
 func (f *FileSystemOperator) Write(dst string, rs io.ReadSeeker) error {
 	// we append the timestamp to the tmp files so that we should never have 2 backups using the same tmp file
-	tmpFile := dst + ".tmp" + "." + strconv.FormatInt(time.Now().UnixNano(), 10)
+	tmpFile := dst + ".tmp" + "." + strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	if err := f.preparePath(dst); err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (f *FileSystemOperator) List(path string) ([]string, error) {
 }
 
 func (f *FileSystemOperator) Upload(src, dst string) error {
-	tmpDst := dst + ".tmp" + "." + strconv.FormatInt(time.Now().UnixNano(), 10)
+	tmpDst := dst + ".tmp" + "." + strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	if f.FileExists(tmpDst) {
 		f.Remove(tmpDst)
 	}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -160,7 +160,7 @@ func (s *BackupStoreDriver) FileTime(filePath string) time.Time {
 	if err != nil || head.ContentLength == nil {
 		return time.Time{}
 	}
-	return aws.TimeValue(head.LastModified)
+	return aws.TimeValue(head.LastModified).UTC()
 }
 
 func (s *BackupStoreDriver) Remove(path string) error {


### PR DESCRIPTION
**Use UTC for all lock comparisons:**
Previously time.Now() was used which returns the time in local time and
therefore the lock expiration check would not be correct, since the
servers modification time is in UTC for S3 and potentially in a different
timezone for the nfs server.

**Remove retry mechanism for lock acquisition:**
we only try to acquire once, since backup operations generally take some
time there is no point in trying to wait for lock acquisition, better to
throw an error and let the calling code retry with an exponential backoff

Since this code is blocking, this potentially also prevents the system
from being unresponsive for 60s in the case where the developer incorrectly
called the blocking code assuming it would be a quick operation.

longhorn/longhorn#612