### PR TITLE
Add retry to S3 service

### DIFF
--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -25,7 +25,7 @@ const (
 func (s *Service) New() (*s3.S3, error) {
 	// get custom endpoint
 	endpoints := os.Getenv("AWS_ENDPOINTS")
-	config := &aws.Config{Region: &s.Region}
+	config := &aws.Config{Region: &s.Region, MaxRetries: aws.Int(3)}
 
 	virtualHostedStyleEnabled := os.Getenv(VirtualHostedStyle)
 	if virtualHostedStyleEnabled == "true" {


### PR DESCRIPTION
A single failed upload of a block should not stop the whole backup, it should be retried.

longhorn/longhorn#1967