### PR TITLE
Support s3 pagination

### DIFF
--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"os"
 )
 
 type Service struct {
@@ -74,17 +74,26 @@ func (s *Service) ListObjects(key, delimiter string) ([]*s3.Object, []*s3.Common
 	defer s.Close()
 	// WARNING: Directory must end in "/" in S3, otherwise it may match
 	// unintentially
-	params := &s3.ListObjectsInput{
+	params := &s3.ListObjectsV2Input{
 		Bucket:    aws.String(s.Bucket),
 		Prefix:    aws.String(key),
 		Delimiter: aws.String(delimiter),
 	}
-	resp, err := svc.ListObjects(params)
+
+	var (
+		objects       []*s3.Object
+		commonPrefixs []*s3.CommonPrefix
+	)
+	err = svc.ListObjectsV2Pages(params, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+		objects = append(objects, page.Contents...)
+		commonPrefixs = append(commonPrefixs, page.CommonPrefixes...)
+		return !lastPage
+	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list objects with param: %+v response: %v error: %v",
-			params, resp.String(), parseAwsError(err))
+		return nil, nil, fmt.Errorf("failed to list objects with param: %+v error: %v",
+			params, parseAwsError(err))
 	}
-	return resp.Contents, resp.CommonPrefixes, nil
+	return objects, commonPrefixs, nil
 }
 
 func (s *Service) HeadObject(key string) (*s3.HeadObjectOutput, error) {


### PR DESCRIPTION
#### Proposed Changes
Use ListObjectsV2Pages to iterates all the pages, reference to:
https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.ListObjectsV2Pages

By the way, the ListObjects has been revised, use the new version ListObjectsV2.
Please refer to:
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html

#### Linked Issues
https://github.com/longhorn/longhorn/issues/1904
