### PR TITLE
Downgrade to use v1 ListObjects

### DIFF
--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -74,7 +74,7 @@ func (s *Service) ListObjects(key, delimiter string) ([]*s3.Object, []*s3.Common
 	defer s.Close()
 	// WARNING: Directory must end in "/" in S3, otherwise it may match
 	// unintentially
-	params := &s3.ListObjectsV2Input{
+	params := &s3.ListObjectsInput{
 		Bucket:    aws.String(s.Bucket),
 		Prefix:    aws.String(key),
 		Delimiter: aws.String(delimiter),
@@ -84,7 +84,7 @@ func (s *Service) ListObjects(key, delimiter string) ([]*s3.Object, []*s3.Common
 		objects       []*s3.Object
 		commonPrefixs []*s3.CommonPrefix
 	)
-	err = svc.ListObjectsV2Pages(params, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+	err = svc.ListObjectsPages(params, func(page *s3.ListObjectsOutput, lastPage bool) bool {
 		objects = append(objects, page.Contents...)
 		commonPrefixs = append(commonPrefixs, page.CommonPrefixes...)
 		return !lastPage


### PR DESCRIPTION
#### Proposed Changes
Looks like ListObjectsV2 isn't supported on GCE.
- https://issuetracker.google.com/issues/155109631
- https://stackoverflow.com/questions/45638871/is-the-listobjectsv2-api-call-implemented-in-google-cloud-storage
- https://cloud.google.com/storage/docs/migrating#migration-simple

So, we downgrade to use v1 API.

#### Linked Issues
https://github.com/longhorn/longhorn/issues/1904