### PR TITLE
Add KubernetesStatus metadata to volume.cfg

### DIFF
--- a/backupstore.go
+++ b/backupstore.go
@@ -10,6 +10,7 @@ import (
 type Volume struct {
 	Name             string
 	Size             int64 `json:",string"`
+	Labels           map[string]string
 	CreatedTime      string
 	LastBackupName   string
 	LastBackupAt     string

--- a/deltablock.go
+++ b/deltablock.go
@@ -325,6 +325,7 @@ func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Back
 	volume.BlockCount = volume.BlockCount + newBlocks
 	// The volume may be expanded
 	volume.Size = config.Volume.Size
+	volume.Labels = config.Labels
 	volume.BackingImageName = config.Volume.BackingImageName
 	volume.BackingImageURL = config.Volume.BackingImageURL
 

--- a/list.go
+++ b/list.go
@@ -2,6 +2,7 @@ package backupstore
 
 import (
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	. "github.com/longhorn/backupstore/logging"
@@ -11,6 +12,7 @@ import (
 type VolumeInfo struct {
 	Name           string
 	Size           int64 `json:",string"`
+	Labels         map[string]string
 	Created        string
 	LastBackupName string
 	LastBackupAt   string
@@ -121,6 +123,7 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 	return &VolumeInfo{
 		Name:             volume.Name,
 		Size:             volume.Size,
+		Labels:           volume.Labels,
 		Created:          volume.CreatedTime,
 		LastBackupName:   volume.LastBackupName,
 		LastBackupAt:     volume.LastBackupAt,


### PR DESCRIPTION
#### Proposed Changes
add PVC + namespace + Workload/Pod name in KubernetesStatus to volume.cfg.

I did not choose to get the **KuberneteStatus** metadata from the per-PVC `backup-backup-xxxx.cfg` is because I don't want to increase the S3 API list calls. We already have an issue with too many S3 API calls which causes the command timeout.

Therefore, I choose to add the **KubernetesStatus** to `volume.cfg` directly to make the `longhorn backup list --volume-only` to have the PVC + namespace + Workerload/Pod name information, then GUI could display this information in the backup list section of Dashboard.

#### Linked Issues
https://github.com/longhorn/longhorn/issues/1539