### PR TITLE
add nfs server mount directory log (#2242)

### DIFF
--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -65,7 +65,7 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 	b.serverPath = u.Host + u.Path
 	b.mountDir = filepath.Join(MountDir, strings.TrimRight(strings.Replace(u.Host, ".", "_", -1), ":"), u.Path)
 	if err := os.MkdirAll(b.mountDir, os.ModeDir|0700); err != nil {
-		return nil, fmt.Errorf("Cannot create mount directory %v for NFS server", b.mountDir)
+		return nil, fmt.Errorf("Cannot create mount directory %v for NFS server: %v", b.mountDir, err)
 	}
 
 	if err := b.mount(); err != nil {


### PR DESCRIPTION
#### Proposed Changes ####

add nfs server mount directory log to resolve ticket '[Question] unable to mount NFS backup' (#2242)

- Add error to log message make directory failed

#### Types of Changes ####

Enhancement

#### Verification ####

#### Linked Issues ####

Refs: https://github.com/longhorn/longhorn/issues/2242

#### Further Comments ####

None

Signed-off-by: Clark Hsu <clark.hsu@suse.com>