### PR TITLE
Error handling backupstore.List when fsops path not exist

### DIFF
--- a/fsops/fsops.go
+++ b/fsops/fsops.go
@@ -114,7 +114,9 @@ func (f *FileSystemOperator) Write(dst string, rs io.ReadSeeker) error {
 
 func (f *FileSystemOperator) List(path string) ([]string, error) {
 	out, err := util.Execute("ls", []string{"-1", f.LocalPath(path)})
-	if err != nil {
+	if err != nil &&
+		!strings.Contains(err.Error(), "No such file or directory") &&
+		!strings.Contains(err.Error(), "cannot open directory") {
 		return nil, err
 	}
 	var result []string


### PR DESCRIPTION
When the volume directory does not exist on NFS backstore should return empty list instead of error.

https://github.com/longhorn/longhorn/issues/2312