### PR TITLE
Support AWS IAM Role

### DIFF
--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -49,6 +49,9 @@ func (s *Service) New() (*s3.S3, error) {
 	if err != nil {
 		return nil, err
 	}
+	if _, err := ses.Config.Credentials.Get(); err != nil {
+		return nil, err
+	}
 	return s3.New(ses), nil
 }
 


### PR DESCRIPTION
#### Proposed Changes
Call `ses.Config.Credentials.Get()`, the AWS SDK would get the temporary role credentials from AWS AssumeRole.
Reference to https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html

#### Linked Issues
https://github.com/longhorn/longhorn/issues/1526