### PR TITLE
Use concurrency job to increase list volume backups performance

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -51,6 +51,14 @@ func RegisterDriver(kind string, initFunc InitFunc) error {
 	return nil
 }
 
+func unregisterDriver(kind string) error {
+	if _, exists := initializers[kind]; !exists {
+		return fmt.Errorf("%s has not been registered", kind)
+	}
+	delete(initializers, kind)
+	return nil
+}
+
 func GetBackupStoreDriver(destURL string) (BackupStoreDriver, error) {
 	if destURL == "" {
 		return nil, fmt.Errorf("Destination URL hasn't been specified")

--- a/list.go
+++ b/list.go
@@ -117,7 +117,7 @@ func List(volumeName, destURL string, volumeOnly bool) (map[string]*VolumeInfo, 
 		jobq.WorkerPoolSize(256),
 	)
 	defer jobQueues.Stop()
-	jobQueueTimeout := 30 * time.Second
+	jobQueueTimeout := time.Minute
 
 	volumeNames := []string{volumeName}
 	if volumeName == "" {

--- a/list.go
+++ b/list.go
@@ -15,6 +15,8 @@ import (
 	"github.com/longhorn/backupstore/util"
 )
 
+const jobQueueTimeout = time.Minute
+
 type VolumeInfo struct {
 	Name           string
 	Size           int64 `json:",string"`
@@ -81,24 +83,43 @@ func addListVolume(volumeName string, driver BackupStoreDriver, volumeOnly bool)
 		return volumeInfo, nil
 	}
 
+	jobQueues := jobq.NewWorkerDispatcher(
+		// init #cpu*16 workers
+		jobq.WorkerN(runtime.NumCPU()*16),
+		// init worker pool size to 50 (same as maximum retentions)
+		jobq.WorkerPoolSize(50),
+	)
+	defer jobQueues.Stop()
+
+	var trackers []jobq.JobTracker
 	for _, backupName := range backupNames {
-		var info *BackupInfo
-		backup, err := loadBackup(backupName, volumeName, driver)
-		if err != nil {
-			log.WithFields(logrus.Fields{
-				LogFieldReason: LogReasonFallback,
-				LogFieldEvent:  LogEventList,
-				LogFieldObject: LogObjectBackup,
-				LogFieldBackup: backupName,
-				LogFieldVolume: volumeName,
-			}).Warn("Failed to load backup in backupstore")
-			info = failedBackupInfo(backupName, volumeName, driver.GetURL(), err)
-		} else if isBackupInProgress(backup) {
-			// for now we don't return in progress backups to the ui
-			continue
-		} else {
-			info = fillBackupInfo(backup, driver.GetURL())
-		}
+		backupName := backupName
+		tracker := jobQueues.QueueTimedFunc(context.Background(), func(ctx context.Context) (interface{}, error) {
+			var info *BackupInfo
+			backup, err := loadBackup(backupName, volumeName, driver)
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					LogFieldReason: LogReasonFallback,
+					LogFieldEvent:  LogEventList,
+					LogFieldObject: LogObjectBackup,
+					LogFieldBackup: backupName,
+					LogFieldVolume: volumeName,
+				}).Warn("Failed to load backup in backupstore")
+				info = failedBackupInfo(backupName, volumeName, driver.GetURL(), err)
+			} else if isBackupInProgress(backup) {
+				// for now we don't return in progress backups to the ui
+			} else {
+				info = fillBackupInfo(backup, driver.GetURL())
+			}
+			return info, nil
+		}, jobQueueTimeout)
+
+		trackers = append(trackers, tracker)
+	}
+
+	for _, tracker := range trackers {
+		payload, _ := tracker.Result()
+		info := payload.(*BackupInfo)
 		volumeInfo.Backups[info.URL] = info
 	}
 	return volumeInfo, nil
@@ -113,11 +134,10 @@ func List(volumeName, destURL string, volumeOnly bool) (map[string]*VolumeInfo, 
 	jobQueues := jobq.NewWorkerDispatcher(
 		// init #cpu*16 workers
 		jobq.WorkerN(runtime.NumCPU()*16),
-		// init worker pool size to 256
+		// init worker pool size to 256 (same as max folders 16*16)
 		jobq.WorkerPoolSize(256),
 	)
 	defer jobQueues.Stop()
-	jobQueueTimeout := time.Minute
 
 	volumeNames := []string{volumeName}
 	if volumeName == "" {

--- a/list_test.go
+++ b/list_test.go
@@ -238,14 +238,14 @@ func BenchmarkListAllVolumeOnly10ms32volumes(b *testing.B) {
 		delay:        10 * time.Millisecond,
 	}
 	m.Init()
-	initFunc := func(destURL string) (BackupStoreDriver, error) {
+	RegisterDriver(mockDriverName, func(destURL string) (BackupStoreDriver, error) {
 		m.destURL = destURL
 		return m, nil
-	}
-	_ = RegisterDriver("mock", initFunc)
+	})
+	defer unregisterDriver(mockDriverName)
 
 	for i := 0; i < b.N; i++ {
-		_, _ = List("", "mock://localhost", true)
+		List("", mockDriverURL, true)
 	}
 }
 
@@ -255,14 +255,14 @@ func BenchmarkListAllVolumeOnly100ms32volumes(b *testing.B) {
 		delay:        100 * time.Millisecond,
 	}
 	m.Init()
-	initFunc := func(destURL string) (BackupStoreDriver, error) {
+	RegisterDriver(mockDriverName, func(destURL string) (BackupStoreDriver, error) {
 		m.destURL = destURL
 		return m, nil
-	}
-	_ = RegisterDriver("mock", initFunc)
+	})
+	defer unregisterDriver(mockDriverName)
 
 	for i := 0; i < b.N; i++ {
-		_, _ = List("", "mock://localhost", true)
+		List("", mockDriverURL, true)
 	}
 }
 
@@ -272,14 +272,14 @@ func BenchmarkListAllVolumeOnly250ms32volumes(b *testing.B) {
 		delay:        250 * time.Millisecond,
 	}
 	m.Init()
-	initFunc := func(destURL string) (BackupStoreDriver, error) {
+	RegisterDriver(mockDriverName, func(destURL string) (BackupStoreDriver, error) {
 		m.destURL = destURL
 		return m, nil
-	}
-	_ = RegisterDriver("mock", initFunc)
+	})
+	defer unregisterDriver(mockDriverName)
 
 	for i := 0; i < b.N; i++ {
-		_, _ = List("", "mock://localhost", true)
+		List("", mockDriverURL, true)
 	}
 }
 
@@ -289,13 +289,93 @@ func BenchmarkListAllVolumeOnly500ms32volumes(b *testing.B) {
 		delay:        500 * time.Millisecond,
 	}
 	m.Init()
-	initFunc := func(destURL string) (BackupStoreDriver, error) {
+	RegisterDriver(mockDriverName, func(destURL string) (BackupStoreDriver, error) {
 		m.destURL = destURL
 		return m, nil
-	}
-	_ = RegisterDriver("mock", initFunc)
+	})
+	defer unregisterDriver(mockDriverName)
 
 	for i := 0; i < b.N; i++ {
-		_, _ = List("", "mock://localhost", true)
+		List("", mockDriverURL, true)
+	}
+}
+
+func BenchmarkListSingleVolumeBackups10ms(b *testing.B) {
+	m := &mockStoreDriver{
+		numOfVolumes: 1,
+		numOfBackups: 50,
+		delay:        10 * time.Millisecond,
+	}
+	m.Init()
+	RegisterDriver(mockDriverName, func(destURL string) (BackupStoreDriver, error) {
+		m.destURL = destURL
+		return m, nil
+	})
+	defer unregisterDriver(mockDriverName)
+
+	for i := 0; i < b.N; i++ {
+		for volumeName := range m.volumeInfos {
+			List(volumeName, mockDriverURL, false)
+		}
+	}
+}
+
+func BenchmarkListSingleVolumeBackups100ms(b *testing.B) {
+	m := &mockStoreDriver{
+		numOfVolumes: 1,
+		numOfBackups: 50,
+		delay:        100 * time.Millisecond,
+	}
+	m.Init()
+	RegisterDriver(mockDriverName, func(destURL string) (BackupStoreDriver, error) {
+		m.destURL = destURL
+		return m, nil
+	})
+	defer unregisterDriver(mockDriverName)
+
+	for i := 0; i < b.N; i++ {
+		for volumeName := range m.volumeInfos {
+			List(volumeName, mockDriverURL, false)
+		}
+	}
+}
+
+func BenchmarkListSingleVolumeBackups250ms(b *testing.B) {
+	m := &mockStoreDriver{
+		numOfVolumes: 1,
+		numOfBackups: 50,
+		delay:        250 * time.Millisecond,
+	}
+	m.Init()
+	RegisterDriver(mockDriverName, func(destURL string) (BackupStoreDriver, error) {
+		m.destURL = destURL
+		return m, nil
+	})
+	defer unregisterDriver(mockDriverName)
+
+	for i := 0; i < b.N; i++ {
+		for volumeName := range m.volumeInfos {
+			List(volumeName, mockDriverURL, false)
+		}
+	}
+}
+
+func BenchmarkListSingleVolumeBackups500ms(b *testing.B) {
+	m := &mockStoreDriver{
+		numOfVolumes: 1,
+		numOfBackups: 50,
+		delay:        500 * time.Millisecond,
+	}
+	m.Init()
+	RegisterDriver(mockDriverName, func(destURL string) (BackupStoreDriver, error) {
+		m.destURL = destURL
+		return m, nil
+	})
+	defer unregisterDriver(mockDriverName)
+
+	for i := 0; i < b.N; i++ {
+		for volumeName := range m.volumeInfos {
+			List(volumeName, mockDriverURL, false)
+		}
 	}
 }


### PR DESCRIPTION
#### Propose change
- Set the job timeout to 1 min (equals to https://github.com/longhorn/longhorn-manager/blob/v1.1.1/util/util.go#L60)
- Use concurrency job to increase list volume backups performance

#### Testing

In my testing (4 CPUs + 800ms delay from LH cluster to S3 MinIO) with 50 volume backups, lists single volume backups time:
- w/o this PR: after 30 secs, the job timeout
- w/ this PR: 0m10.490s

Golang Benchmark comparison: 
- w/o this PR:
   ```shell
   $ go test -race -v -cover -count=1  -covermode atomic *.go -bench=. -benchmem

   BenchmarkListSingleVolumeBackups10ms
   BenchmarkListSingleVolumeBackups10ms-4                 2         597725303 ns/op          406836 B/op       5562 allocs/op
   BenchmarkListSingleVolumeBackups100ms
   BenchmarkListSingleVolumeBackups100ms-4                1        5370743053 ns/op          416200 B/op       5689 allocs/op
   BenchmarkListSingleVolumeBackups250ms
   BenchmarkListSingleVolumeBackups250ms-4                1        13163864998 ns/op         414088 B/op       5666 allocs/op
   BenchmarkListSingleVolumeBackups500ms
   BenchmarkListSingleVolumeBackups500ms-4                1        26199054045 ns/op         417864 B/op       5704 allocs/op
   ```

- w/ this PR:
   ```
   $ go test -race -v -cover -count=1  -covermode atomic *.go -bench=. -benchmem
   BenchmarkListSingleVolumeBackups10ms
   BenchmarkListSingleVolumeBackups10ms-4                24          47451143 ns/op          463214 B/op       6344 allocs/op
   BenchmarkListSingleVolumeBackups100ms
   BenchmarkListSingleVolumeBackups100ms-4                4         322939040 ns/op          465954 B/op       6391 allocs/op
   BenchmarkListSingleVolumeBackups250ms
   BenchmarkListSingleVolumeBackups250ms-4                2         767439066 ns/op          471524 B/op       6466 allocs/op
   BenchmarkListSingleVolumeBackups500ms
   BenchmarkListSingleVolumeBackups500ms-4                1        1519768550 ns/op          494920 B/op       6733 allocs/op
   ```

#### Issue
https://github.com/longhorn/longhorn/issues/2543