### PR TITLE
Add new API to get the config last modification time

### DIFF
--- a/backupstore.go
+++ b/backupstore.go
@@ -96,7 +96,7 @@ func removeVolume(volumeName string, driver BackupStoreDriver) error {
 	return nil
 }
 
-func EncodeMetadataURL(backupName, volumeName, destURL string) string {
+func EncodeConfigURL(backupName, volumeName, destURL string) string {
 	v := url.Values{}
 	v.Add("volume", volumeName)
 	if backupName != "" {
@@ -105,7 +105,7 @@ func EncodeMetadataURL(backupName, volumeName, destURL string) string {
 	return destURL + "?" + v.Encode()
 }
 
-func DecodeMetadataURL(backupURL string) (string, string, string, error) {
+func DecodeConfigURL(backupURL string) (string, string, string, error) {
 	u, err := url.Parse(backupURL)
 	if err != nil {
 		return "", "", "", err
@@ -125,7 +125,7 @@ func DecodeMetadataURL(backupURL string) (string, string, string, error) {
 }
 
 func LoadVolume(backupURL string) (*Volume, error) {
-	_, volumeName, _, err := DecodeMetadataURL(backupURL)
+	_, volumeName, _, err := DecodeConfigURL(backupURL)
 	if err != nil {
 		return nil, err
 	}

--- a/backupstore.go
+++ b/backupstore.go
@@ -96,7 +96,7 @@ func removeVolume(volumeName string, driver BackupStoreDriver) error {
 	return nil
 }
 
-func EncodeConfigURL(backupName, volumeName, destURL string) string {
+func EncodeBackupURL(backupName, volumeName, destURL string) string {
 	v := url.Values{}
 	v.Add("volume", volumeName)
 	if backupName != "" {
@@ -105,7 +105,7 @@ func EncodeConfigURL(backupName, volumeName, destURL string) string {
 	return destURL + "?" + v.Encode()
 }
 
-func DecodeConfigURL(backupURL string) (string, string, string, error) {
+func DecodeBackupURL(backupURL string) (string, string, string, error) {
 	u, err := url.Parse(backupURL)
 	if err != nil {
 		return "", "", "", err
@@ -125,7 +125,7 @@ func DecodeConfigURL(backupURL string) (string, string, string, error) {
 }
 
 func LoadVolume(backupURL string) (*Volume, error) {
-	_, volumeName, _, err := DecodeConfigURL(backupURL)
+	_, volumeName, _, err := DecodeBackupURL(backupURL)
 	if err != nil {
 		return nil, err
 	}

--- a/backupstore_test.go
+++ b/backupstore_test.go
@@ -7,38 +7,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEncodeAndDecodeMetadataURL(t *testing.T) {
+func TestEncodeAndDecodeConfigURL(t *testing.T) {
 	testCases := []struct {
 		volumeName        string
 		backupName        string
 		destURL           string
 		expectDecodeError bool
-		expectMetadataURL string
+		expectConfigURL   string
 	}{
 		{
-			volumeName:        "vol-1",
-			destURL:           "s3://backupstore@minio/",
-			expectMetadataURL: "s3://backupstore@minio/?volume=vol-1",
+			volumeName:      "vol-1",
+			destURL:         "s3://backupstore@minio/",
+			expectConfigURL: "s3://backupstore@minio/?volume=vol-1",
 		},
 		{
-			volumeName:        "vol-2",
-			backupName:        "backup-2",
-			destURL:           "s3://backupstore@minio/",
-			expectMetadataURL: "s3://backupstore@minio/?backup=backup-2&volume=vol-2",
+			volumeName:      "vol-2",
+			backupName:      "backup-2",
+			destURL:         "s3://backupstore@minio/",
+			expectConfigURL: "s3://backupstore@minio/?backup=backup-2&volume=vol-2",
 		},
 		{
 			// Test invalid volume name
 			volumeName:        "-3-vol",
 			destURL:           "s3://backupstore@minio/",
 			expectDecodeError: true,
-			expectMetadataURL: "s3://backupstore@minio/?volume=-3-vol",
+			expectConfigURL:   "s3://backupstore@minio/?volume=-3-vol",
 		},
 		{
 			// Test invalid backup name
 			volumeName:        "vol-4",
 			backupName:        "-4-backup",
 			destURL:           "s3://backupstore@minio/",
-			expectMetadataURL: "s3://backupstore@minio/?backup=-4-backup&volume=vol-4",
+			expectConfigURL:   "s3://backupstore@minio/?backup=-4-backup&volume=vol-4",
 			expectDecodeError: true,
 		},
 	}
@@ -47,10 +47,10 @@ func TestEncodeAndDecodeMetadataURL(t *testing.T) {
 		t.Run(fmt.Sprintf("%s%s&%s", tc.destURL, tc.backupName, tc.volumeName), func(t *testing.T) {
 			assert := assert.New(t)
 
-			gotMetadataURL := EncodeMetadataURL(tc.backupName, tc.volumeName, tc.destURL)
-			assert.Equal(gotMetadataURL, tc.expectMetadataURL)
+			gotConfigURL := EncodeConfigURL(tc.backupName, tc.volumeName, tc.destURL)
+			assert.Equal(gotConfigURL, tc.expectConfigURL)
 
-			backupName, volumeName, destURL, err := DecodeMetadataURL(gotMetadataURL)
+			backupName, volumeName, destURL, err := DecodeConfigURL(gotConfigURL)
 			if tc.expectDecodeError {
 				assert.NotNil(err)
 			} else {

--- a/backupstore_test.go
+++ b/backupstore_test.go
@@ -7,38 +7,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEncodeAndDecodeConfigURL(t *testing.T) {
+func TestEncodeAndDecodeBackupURL(t *testing.T) {
 	testCases := []struct {
 		volumeName        string
 		backupName        string
 		destURL           string
 		expectDecodeError bool
-		expectConfigURL   string
+		expectBackupURL   string
 	}{
 		{
 			volumeName:      "vol-1",
 			destURL:         "s3://backupstore@minio/",
-			expectConfigURL: "s3://backupstore@minio/?volume=vol-1",
+			expectBackupURL: "s3://backupstore@minio/?volume=vol-1",
 		},
 		{
 			volumeName:      "vol-2",
 			backupName:      "backup-2",
 			destURL:         "s3://backupstore@minio/",
-			expectConfigURL: "s3://backupstore@minio/?backup=backup-2&volume=vol-2",
+			expectBackupURL: "s3://backupstore@minio/?backup=backup-2&volume=vol-2",
 		},
 		{
 			// Test invalid volume name
 			volumeName:        "-3-vol",
 			destURL:           "s3://backupstore@minio/",
 			expectDecodeError: true,
-			expectConfigURL:   "s3://backupstore@minio/?volume=-3-vol",
+			expectBackupURL:   "s3://backupstore@minio/?volume=-3-vol",
 		},
 		{
 			// Test invalid backup name
 			volumeName:        "vol-4",
 			backupName:        "-4-backup",
 			destURL:           "s3://backupstore@minio/",
-			expectConfigURL:   "s3://backupstore@minio/?backup=-4-backup&volume=vol-4",
+			expectBackupURL:   "s3://backupstore@minio/?backup=-4-backup&volume=vol-4",
 			expectDecodeError: true,
 		},
 	}
@@ -47,10 +47,10 @@ func TestEncodeAndDecodeConfigURL(t *testing.T) {
 		t.Run(fmt.Sprintf("%s%s&%s", tc.destURL, tc.backupName, tc.volumeName), func(t *testing.T) {
 			assert := assert.New(t)
 
-			gotConfigURL := EncodeConfigURL(tc.backupName, tc.volumeName, tc.destURL)
-			assert.Equal(gotConfigURL, tc.expectConfigURL)
+			gotBackupURL := EncodeBackupURL(tc.backupName, tc.volumeName, tc.destURL)
+			assert.Equal(gotBackupURL, tc.expectBackupURL)
 
-			backupName, volumeName, destURL, err := DecodeConfigURL(gotConfigURL)
+			backupName, volumeName, destURL, err := DecodeBackupURL(gotBackupURL)
 			if tc.expectDecodeError {
 				assert.NotNil(err)
 			} else {

--- a/cmd/head.go
+++ b/cmd/head.go
@@ -11,9 +11,10 @@ import (
 
 func GetConfigMetadataCmd() cli.Command {
 	return cli.Command{
-		Name:   "head",
-		Usage:  "get the config metadata",
-		Action: cmdGetConfigMetadata,
+		Name:        "head",
+		Usage:       "get the config metadata",
+		Description: "this returns the last modification time of a config file for now",
+		Action:      cmdGetConfigMetadata,
 	}
 }
 

--- a/cmd/head.go
+++ b/cmd/head.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+
+	"github.com/longhorn/backupstore"
+	"github.com/longhorn/backupstore/util"
+)
+
+func GetConfigMetadataCmd() cli.Command {
+	return cli.Command{
+		Name:   "head",
+		Usage:  "get the config metadata",
+		Action: cmdGetConfigMetadata,
+	}
+}
+
+func cmdGetConfigMetadata(c *cli.Context) {
+	if err := doGetConfigMetadata(c); err != nil {
+		panic(err)
+	}
+}
+
+func doGetConfigMetadata(c *cli.Context) error {
+	var err error
+
+	if c.NArg() == 0 {
+		return RequiredMissingError("dest URL")
+	}
+	destURL := c.Args()[0]
+	if destURL == "" {
+		return RequiredMissingError("dest URL")
+	}
+	destURL = util.UnescapeURL(destURL)
+
+	info, err := backupstore.GetConfigMetadata(destURL)
+	if err != nil {
+		return err
+	}
+	data, err := ResponseOutput(info)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}

--- a/deltablock.go
+++ b/deltablock.go
@@ -162,7 +162,7 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 				LogFieldObject:   LogObjectSnapshot,
 				LogFieldSnapshot: backup.SnapshotName,
 				LogFieldVolume:   volume.Name,
-			}).Debug("Create full snapshot metadata")
+			}).Debug("Create full snapshot config")
 		} else if backup.SnapshotName != "" && !deltaOps.HasSnapshot(backup.SnapshotName, volume.Name) {
 			log.WithFields(logrus.Fields{
 				LogFieldReason:   LogReasonFallback,
@@ -181,7 +181,7 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 		LogFieldEvent:        LogEventCompare,
 		LogFieldSnapshot:     snapshot.Name,
 		LogFieldLastSnapshot: backupRequest.getLastSnapshotName(),
-	}).Debug("Generating snapshot changed blocks metadata")
+	}).Debug("Generating snapshot changed blocks config")
 	delta, err := deltaOps.CompareSnapshot(snapshot.Name, backupRequest.getLastSnapshotName(), volume.Name)
 	if err != nil {
 		deltaOps.CloseSnapshot(snapshot.Name, volume.Name)
@@ -198,7 +198,7 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 		LogFieldEvent:        LogEventCompare,
 		LogFieldSnapshot:     snapshot.Name,
 		LogFieldLastSnapshot: backupRequest.getLastSnapshotName(),
-	}).Debug("Generated snapshot changed blocks metadata")
+	}).Debug("Generated snapshot changed blocks config")
 
 	log.WithFields(logrus.Fields{
 		LogFieldReason:     LogReasonStart,
@@ -241,7 +241,7 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Backup, lastBackup *Backup,
 	bsDriver BackupStoreDriver) (int, string, error) {
 
-	// create an in progress backup metadata file
+	// create an in progress backup config file
 	if err := saveBackup(&Backup{Name: deltaBackup.Name, VolumeName: deltaBackup.VolumeName,
 		CreatedTime: ""}, bsDriver); err != nil {
 		return 0, "", err
@@ -339,7 +339,7 @@ func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Back
 		return progress, "", err
 	}
 
-	return PROGRESS_PERCENTAGE_BACKUP_TOTAL, EncodeMetadataURL(backup.Name, volume.Name, destURL), nil
+	return PROGRESS_PERCENTAGE_BACKUP_TOTAL, EncodeConfigURL(backup.Name, volume.Name, destURL), nil
 }
 
 func mergeSnapshotMap(deltaBackup, lastBackup *Backup) *Backup {
@@ -402,7 +402,7 @@ func RestoreDeltaBlockBackup(config *DeltaRestoreConfig) error {
 		return err
 	}
 
-	srcBackupName, srcVolumeName, _, err := DecodeMetadataURL(backupURL)
+	srcBackupName, srcVolumeName, _, err := DecodeConfigURL(backupURL)
 	if err != nil {
 		return err
 	}
@@ -543,7 +543,7 @@ func RestoreDeltaBlockBackupIncrementally(config *DeltaRestoreConfig) error {
 		return err
 	}
 
-	srcBackupName, srcVolumeName, _, err := DecodeMetadataURL(backupURL)
+	srcBackupName, srcVolumeName, _, err := DecodeConfigURL(backupURL)
 	if err != nil {
 		return err
 	}
@@ -771,7 +771,7 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 		return err
 	}
 
-	backupName, volumeName, _, err := DecodeMetadataURL(backupURL)
+	backupName, volumeName, _, err := DecodeConfigURL(backupURL)
 	if err != nil {
 		return err
 	}

--- a/deltablock.go
+++ b/deltablock.go
@@ -339,7 +339,7 @@ func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Back
 		return progress, "", err
 	}
 
-	return PROGRESS_PERCENTAGE_BACKUP_TOTAL, EncodeConfigURL(backup.Name, volume.Name, destURL), nil
+	return PROGRESS_PERCENTAGE_BACKUP_TOTAL, EncodeBackupURL(backup.Name, volume.Name, destURL), nil
 }
 
 func mergeSnapshotMap(deltaBackup, lastBackup *Backup) *Backup {
@@ -402,7 +402,7 @@ func RestoreDeltaBlockBackup(config *DeltaRestoreConfig) error {
 		return err
 	}
 
-	srcBackupName, srcVolumeName, _, err := DecodeConfigURL(backupURL)
+	srcBackupName, srcVolumeName, _, err := DecodeBackupURL(backupURL)
 	if err != nil {
 		return err
 	}
@@ -543,7 +543,7 @@ func RestoreDeltaBlockBackupIncrementally(config *DeltaRestoreConfig) error {
 		return err
 	}
 
-	srcBackupName, srcVolumeName, _, err := DecodeConfigURL(backupURL)
+	srcBackupName, srcVolumeName, _, err := DecodeBackupURL(backupURL)
 	if err != nil {
 		return err
 	}
@@ -771,7 +771,7 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 		return err
 	}
 
-	backupName, volumeName, _, err := DecodeConfigURL(backupURL)
+	backupName, volumeName, _, err := DecodeBackupURL(backupURL)
 	if err != nil {
 		return err
 	}

--- a/head.go
+++ b/head.go
@@ -1,0 +1,36 @@
+package backupstore
+
+import (
+	"fmt"
+	"time"
+)
+
+type ConfigMetadata struct {
+	ModificationTime time.Time
+}
+
+func GetConfigMetadata(url string) (*ConfigMetadata, error) {
+	driver, err := GetBackupStoreDriver(url)
+	if err != nil {
+		return nil, err
+	}
+
+	backupName, volumeName, _, err := DecodeMetadataURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var filePath string
+	if backupName != "" {
+		filePath = getBackupConfigPath(backupName, volumeName)
+	} else {
+		filePath = getVolumeFilePath(volumeName)
+	}
+
+	if !driver.FileExists(filePath) {
+		return &ConfigMetadata{}, fmt.Errorf("cannot find %v in backupstore", filePath)
+	}
+
+	modificationTime := driver.FileTime(filePath)
+	return &ConfigMetadata{ModificationTime: modificationTime}, nil
+}

--- a/head.go
+++ b/head.go
@@ -15,7 +15,7 @@ func GetConfigMetadata(url string) (*ConfigMetadata, error) {
 		return nil, err
 	}
 
-	backupName, volumeName, _, err := DecodeConfigURL(url)
+	backupName, volumeName, _, err := DecodeBackupURL(url)
 	if err != nil {
 		return nil, err
 	}

--- a/head.go
+++ b/head.go
@@ -15,7 +15,7 @@ func GetConfigMetadata(url string) (*ConfigMetadata, error) {
 		return nil, err
 	}
 
-	backupName, volumeName, _, err := DecodeMetadataURL(url)
+	backupName, volumeName, _, err := DecodeConfigURL(url)
 	if err != nil {
 		return nil, err
 	}

--- a/inspect.go
+++ b/inspect.go
@@ -14,7 +14,7 @@ func InspectVolume(volumeURL string) (*VolumeInfo, error) {
 		return nil, err
 	}
 
-	_, volumeName, _, err := DecodeMetadataURL(volumeURL)
+	_, volumeName, _, err := DecodeConfigURL(volumeURL)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func InspectBackup(backupURL string) (*BackupInfo, error) {
 		return nil, err
 	}
 
-	backupName, volumeName, _, err := DecodeMetadataURL(backupURL)
+	backupName, volumeName, _, err := DecodeConfigURL(backupURL)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 func fillBackupInfo(backup *Backup, destURL string) *BackupInfo {
 	return &BackupInfo{
 		Name:            backup.Name,
-		URL:             EncodeMetadataURL(backup.Name, backup.VolumeName, destURL),
+		URL:             EncodeConfigURL(backup.Name, backup.VolumeName, destURL),
 		SnapshotName:    backup.SnapshotName,
 		SnapshotCreated: backup.SnapshotCreatedAt,
 		Created:         backup.CreatedTime,

--- a/inspect.go
+++ b/inspect.go
@@ -14,7 +14,7 @@ func InspectVolume(volumeURL string) (*VolumeInfo, error) {
 		return nil, err
 	}
 
-	_, volumeName, _, err := DecodeConfigURL(volumeURL)
+	_, volumeName, _, err := DecodeBackupURL(volumeURL)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func InspectBackup(backupURL string) (*BackupInfo, error) {
 		return nil, err
 	}
 
-	backupName, volumeName, _, err := DecodeConfigURL(backupURL)
+	backupName, volumeName, _, err := DecodeBackupURL(backupURL)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 func fillBackupInfo(backup *Backup, destURL string) *BackupInfo {
 	return &BackupInfo{
 		Name:            backup.Name,
-		URL:             EncodeConfigURL(backup.Name, backup.VolumeName, destURL),
+		URL:             EncodeBackupURL(backup.Name, backup.VolumeName, destURL),
 		SnapshotName:    backup.SnapshotName,
 		SnapshotCreated: backup.SnapshotCreatedAt,
 		Created:         backup.CreatedTime,

--- a/list_inspect_test.go
+++ b/list_inspect_test.go
@@ -187,7 +187,7 @@ func TestInspectVolume(t *testing.T) {
 	// create pvc-1 folder and config
 	m.fs.MkdirAll(getVolumePath("pvc-1"), 0755)
 
-	volumeURL := EncodeConfigURL("", "pvc-1", mockDriverURL)
+	volumeURL := EncodeBackupURL("", "pvc-1", mockDriverURL)
 	volumeInfo, err := InspectVolume(volumeURL)
 	assert.Error(err)
 	assert.Nil(volumeInfo)
@@ -197,7 +197,7 @@ func TestInspectVolume(t *testing.T) {
 		[]byte(`{"Name":"pvc-1","Size":"2147483648","CreatedTime":"2021-05-12T00:52:01Z","LastBackupName":"backup-3","LastBackupAt":"2021-05-17T05:31:01Z"}`), 0644)
 
 	// inspect backup volume config
-	volumeURL = EncodeConfigURL("", "pvc-1", mockDriverURL)
+	volumeURL = EncodeBackupURL("", "pvc-1", mockDriverURL)
 	volumeInfo, err = InspectVolume(volumeURL)
 	assert.NoError(err)
 	assert.Equal(volumeInfo.Name, "pvc-1")
@@ -217,7 +217,7 @@ func TestInspectBackup(t *testing.T) {
 	// create pvc-1 folder and config
 	m.fs.MkdirAll(getVolumePath("pvc-1"), 0755)
 
-	backupURL := EncodeConfigURL("backup-1", "pvc-1", mockDriverURL)
+	backupURL := EncodeBackupURL("backup-1", "pvc-1", mockDriverURL)
 	backupInfo, err := InspectBackup(backupURL)
 	assert.Error(err)
 	assert.Nil(backupInfo)

--- a/singlefile.go
+++ b/singlefile.go
@@ -70,7 +70,7 @@ func CreateSingleFileBackup(volume *Volume, snapshot *Snapshot, filePath, destUR
 		LogFieldSnapshot: snapshot.Name,
 	}).Debug("Created backup")
 
-	return EncodeMetadataURL(backup.Name, volume.Name, destURL), nil
+	return EncodeConfigURL(backup.Name, volume.Name, destURL), nil
 }
 
 func RestoreSingleFileBackup(backupURL, path string) (string, error) {
@@ -79,7 +79,7 @@ func RestoreSingleFileBackup(backupURL, path string) (string, error) {
 		return "", err
 	}
 
-	srcBackupName, srcVolumeName, _, err := DecodeMetadataURL(backupURL)
+	srcBackupName, srcVolumeName, _, err := DecodeConfigURL(backupURL)
 	if err != nil {
 		return "", err
 	}
@@ -110,7 +110,7 @@ func DeleteSingleFileBackup(backupURL string) error {
 		return err
 	}
 
-	backupName, volumeName, _, err := DecodeMetadataURL(backupURL)
+	backupName, volumeName, _, err := DecodeConfigURL(backupURL)
 	if err != nil {
 		return err
 	}

--- a/singlefile.go
+++ b/singlefile.go
@@ -70,7 +70,7 @@ func CreateSingleFileBackup(volume *Volume, snapshot *Snapshot, filePath, destUR
 		LogFieldSnapshot: snapshot.Name,
 	}).Debug("Created backup")
 
-	return EncodeConfigURL(backup.Name, volume.Name, destURL), nil
+	return EncodeBackupURL(backup.Name, volume.Name, destURL), nil
 }
 
 func RestoreSingleFileBackup(backupURL, path string) (string, error) {
@@ -79,7 +79,7 @@ func RestoreSingleFileBackup(backupURL, path string) (string, error) {
 		return "", err
 	}
 
-	srcBackupName, srcVolumeName, _, err := DecodeConfigURL(backupURL)
+	srcBackupName, srcVolumeName, _, err := DecodeBackupURL(backupURL)
 	if err != nil {
 		return "", err
 	}
@@ -110,7 +110,7 @@ func DeleteSingleFileBackup(backupURL string) error {
 		return err
 	}
 
-	backupName, volumeName, _, err := DecodeConfigURL(backupURL)
+	backupName, volumeName, _, err := DecodeBackupURL(backupURL)
 	if err != nil {
 		return err
 	}

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -348,7 +348,7 @@ func (s *TestSuite) TestBackupBasic(c *C) {
 		c.Assert(err, IsNil)
 
 		// inspect the backup config
-		backupName, volumeName, _, err := backupstore.DecodeConfigURL(backup)
+		backupName, volumeName, _, err := backupstore.DecodeBackupURL(backup)
 		c.Assert(err, IsNil)
 		backupInfo, err := backupstore.InspectBackup(backup)
 		c.Assert(err, IsNil)
@@ -388,13 +388,13 @@ func (s *TestSuite) TestBackupBasic(c *C) {
 	c.Assert(len(volumeName.Backups), Equals, snapshotCounts)
 
 	// inspect backup volume config
-	volumeInfo, err := backupstore.InspectVolume(backupstore.EncodeConfigURL("", volume.v.Name, s.getDestURL()))
+	volumeInfo, err := backupstore.InspectVolume(backupstore.EncodeBackupURL("", volume.v.Name, s.getDestURL()))
 	c.Assert(err, IsNil)
 	c.Assert(volumeInfo.Name, Equals, volume.v.Name)
 	c.Assert(volumeInfo.Size, Equals, volumeSize)
 	c.Assert(volumeInfo.Created, Equals, volume.v.CreatedTime)
 	c.Assert(volumeInfo.DataStored, Equals, int64(snapshotCounts*backupstore.DEFAULT_BLOCK_SIZE))
-	backupName, _, _, err := backupstore.DecodeConfigURL(backupN)
+	backupName, _, _, err := backupstore.DecodeBackupURL(backupN)
 	c.Assert(err, IsNil)
 	c.Assert(volumeInfo.LastBackupName, Equals, backupName)
 	c.Assert(volumeInfo.LastBackupAt, Not(Equals), "")

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -347,8 +347,8 @@ func (s *TestSuite) TestBackupBasic(c *C) {
 		err = exec.Command("diff", volume.Snapshots[i].Name, restore).Run()
 		c.Assert(err, IsNil)
 
-		// inspect the historical backup metadata
-		backupName, volumeName, _, err := backupstore.DecodeMetadataURL(backup)
+		// inspect the backup config
+		backupName, volumeName, _, err := backupstore.DecodeConfigURL(backup)
 		c.Assert(err, IsNil)
 		backupInfo, err := backupstore.InspectBackup(backup)
 		c.Assert(err, IsNil)
@@ -379,7 +379,7 @@ func (s *TestSuite) TestBackupBasic(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(len(volumeName.Backups), Equals, 0)
 
-	// list backup volume name and it's historical backups
+	// list backup volume name and it's backups
 	listName, err = backupstore.List(volume.v.Name, s.getDestURL(), false)
 	c.Assert(err, IsNil)
 	c.Assert(len(listName), Equals, 1)
@@ -387,14 +387,14 @@ func (s *TestSuite) TestBackupBasic(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(len(volumeName.Backups), Equals, snapshotCounts)
 
-	// inspect backup volume metadata
-	volumeInfo, err := backupstore.InspectVolume(backupstore.EncodeMetadataURL("", volume.v.Name, s.getDestURL()))
+	// inspect backup volume config
+	volumeInfo, err := backupstore.InspectVolume(backupstore.EncodeConfigURL("", volume.v.Name, s.getDestURL()))
 	c.Assert(err, IsNil)
 	c.Assert(volumeInfo.Name, Equals, volume.v.Name)
 	c.Assert(volumeInfo.Size, Equals, volumeSize)
 	c.Assert(volumeInfo.Created, Equals, volume.v.CreatedTime)
 	c.Assert(volumeInfo.DataStored, Equals, int64(snapshotCounts*backupstore.DEFAULT_BLOCK_SIZE))
-	backupName, _, _, err := backupstore.DecodeMetadataURL(backupN)
+	backupName, _, _, err := backupstore.DecodeConfigURL(backupN)
 	c.Assert(err, IsNil)
 	c.Assert(volumeInfo.LastBackupName, Equals, backupName)
 	c.Assert(volumeInfo.LastBackupAt, Not(Equals), "")


### PR DESCRIPTION
#### Propose Changes

- Rename backup volume config and backup config configuration-related code to use the word `config` instead of `metadata` to make it more clear.
- `backup config-metadata`: a new command to get the config (backup volume config _or_ backup config) metadata to get the last modification time. This could prevent the longhorn manager read the config periodically even the config did not change.

#### Issue

https://github.com/longhorn/longhorn/issues/1761