### PR TITLE
nfs: only return coalesce error when last NFSv4 version fails to mount

### DIFF
--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -85,8 +85,7 @@ func (b *BackupStoreDriver) mount() (err error) {
 
 	defer func() {
 		if err != nil {
-			//err = errors.New(fmt.Sprintf("Cannot mount using NFSv4: %s", strings.Join(errs, ";")))
-			err = errors.New(fmt.Sprintf("Cannot mount using NFSv4: %s", errs, ";"))
+			err = errors.New(fmt.Sprintf("Cannot mount using NFSv4: %s", strings.Join(errs, ";")))
 		}
 	}()
 


### PR DESCRIPTION
nfs: only return coalesce error when last NFSv4 version fails to mount

(1) Only return coalesce error when last NFSv4 version fails to mount.
(2) Remove NFSv3 try mount and umount from defer function.

Signed-off-by: Derek Su <derek.su@suse.com>