### PR TITLE
nfs: only return coalesce error when last NFSv4 version fails to mount

### DIFF
--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -81,28 +81,25 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 }
 
 func (b *BackupStoreDriver) mount() (err error) {
-	defer func() {
-		if err != nil {
-			if _, err := util.Execute("mount", []string{"-t", "nfs", "-o", "nfsvers=3", "-o", "nolock", "-o", "actimeo=1", b.serverPath, b.mountDir}); err != nil {
-				return
-			}
-			err = errors.Wrapf(err, "nfsv4 mount failed but nfsv3 mount succeeded, may be due to server only supporting nfsv3")
-			if err := b.unmount(); err != nil {
-				log.Errorf("failed to clean up nfsv3 test mount: %v", err)
-			}
-		}
-	}()
+	var errs []string
 
 	if !util.IsMounted(b.mountDir) {
 		for _, version := range MinorVersions {
 			log.Debugf("attempting mount for nfs path %v with nfsvers %v", b.serverPath, version)
 			_, err = util.Execute("mount", []string{"-t", "nfs4", "-o", fmt.Sprintf("nfsvers=%v", version), "-o", "actimeo=1", b.serverPath, b.mountDir})
-			if err == nil || !strings.Contains(err.Error(), UnsupportedProtocolError) {
-				break
+			if err == nil {
+				return nil
 			}
+
+			errs = append(errs, fmt.Sprintf("ver=%v: %v", version, err.Error()))
 		}
 	}
-	return err
+
+	if len(errs) > 0 {
+		return errors.New(fmt.Sprintf("Cannot mount using NFSv4: %s", strings.Join(errs, ";")))
+	}
+
+	return nil
 }
 
 func (b *BackupStoreDriver) unmount() error {


### PR DESCRIPTION
(1) Only return coalesce error when last NFSv4 version fails to mount.
(2) Remove NFSv3 try mount/umount from defer function.

Signed-off-by: Derek Su <derek.su@suse.com>