### PR TITLE
feat(nfs): test connection

### DIFF
--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -3,9 +3,9 @@ package nfs
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/longhorn/backupstore"
 	"github.com/longhorn/backupstore/fsops"
@@ -64,7 +64,7 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 
 	b.serverPath = u.Host + u.Path
 	b.mountDir = filepath.Join(MountDir, strings.TrimRight(strings.Replace(u.Host, ".", "_", -1), ":"), u.Path)
-	if err := os.MkdirAll(b.mountDir, os.ModeDir|0700); err != nil {
+	if _, err = util.ExecuteWithCustomTimeout("mkdir", []string{"-m", "700", "-p", b.mountDir}, 3*time.Second); err != nil {
 		return nil, fmt.Errorf("Cannot create mount directory %v for NFS server: %v", b.mountDir, err)
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -127,11 +127,20 @@ func ValidateName(name string) bool {
 }
 
 func Execute(binary string, args []string) (string, error) {
-	var output []byte
-	var err error
-
 	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 	defer cancel()
+	return execute(ctx, binary, args)
+}
+
+func ExecuteWithCustomTimeout(binary string, args []string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return execute(ctx, binary, args)
+}
+
+func execute(ctx context.Context, binary string, args []string) (string, error) {
+	var output []byte
+	var err error
 
 	cmd := exec.CommandContext(ctx, binary, args...)
 	done := make(chan struct{})


### PR DESCRIPTION
If we lose NFS connection after setting up backup-target and then we try to initialize NFS BackupStoreDriver again in another program, the program may be stuck in [`MkdirAll`](https://github.com/longhorn/backupstore/blob/56ddc538b85950b02c37432e4854e74f2647ca61/nfs/nfs.go#L67) or [`List`](https://github.com/longhorn/backupstore/blob/56ddc538b85950b02c37432e4854e74f2647ca61/nfs/nfs.go#L74). So I use `util.Execute` to avoid being stuck in `mkdir` command.

Issue: https://github.com/harvester/harvester/issues/2631