### PR TITLE
fix(http): set Proxy function for all http client of s3 driver

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -61,13 +61,12 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 	}
 
 	// add custom ca to http client that is used by s3 service
-	if customCerts := getCustomCerts(); customCerts != nil {
-		client, err := http.GetClientWithCustomCerts(customCerts)
-		if err != nil {
-			return nil, err
-		}
-		b.service.Client = client
+	customCerts := getCustomCerts()
+	client, err := http.GetClientWithCustomCerts(customCerts)
+	if err != nil {
+		return nil, err
 	}
+	b.service.Client = client
 
 	//Leading '/' can cause mystery problems for s3
 	b.path = strings.TrimLeft(b.path, "/")


### PR DESCRIPTION
Use `GetClient` to create the http client for s3 driver.

longhorn/longhorn#5054

Regression test: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2937/