### PR TITLE
Use IsNotMountPoint() for backward compatibility

### DIFF
--- a/cifs/cifs.go
+++ b/cifs/cifs.go
@@ -90,7 +90,7 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 }
 
 func (b *BackupStoreDriver) mount() error {
-	mounter := mount.NewWithoutSystemd("")
+	mounter := mount.New(b.mountDir)
 
 	mounted, err := util.EnsureMountPoint(KIND, b.mountDir, mounter, log)
 	if err != nil {

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -86,7 +86,7 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 }
 
 func (b *BackupStoreDriver) mount() error {
-	mounter := mount.NewWithoutSystemd("")
+	mounter := mount.New(b.mountDir)
 
 	mounted, err := util.EnsureMountPoint(KIND, b.mountDir, mounter, log)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -272,7 +272,7 @@ func EnsureMountPoint(Kind, mountPoint string, mounter mount.Interface, log logr
 		}
 	}()
 
-	mounted, err = mounter.IsMountPoint(mountPoint)
+	notMounted, err := mount.IsNotMountPoint(mounter, mountPoint)
 	if err != nil {
 		if strings.Contains(err.Error(), syscall.ENOENT.Error()) {
 			return false, nil
@@ -281,9 +281,9 @@ func EnsureMountPoint(Kind, mountPoint string, mounter mount.Interface, log logr
 
 	IsCorruptedMnt := mount.IsCorruptedMnt(err)
 	if !IsCorruptedMnt {
-		logrus.Warnf("Mount point %v is trying reading dir to make sure it is healthy", mountPoint)
+		log.Warnf("Mount point %v is trying reading dir to make sure it is healthy", mountPoint)
 		if _, readErr := ioutil.ReadDir(mountPoint); readErr != nil {
-			logrus.WithError(readErr).Warnf("Mount point %v was identified as corrupt by ReadDir", mountPoint)
+			log.WithError(readErr).Warnf("Mount point %v was identified as corrupt by ReadDir", mountPoint)
 			IsCorruptedMnt = true
 		}
 	}
@@ -293,10 +293,10 @@ func EnsureMountPoint(Kind, mountPoint string, mounter mount.Interface, log logr
 		if mntErr := cleanupMount(mountPoint, mounter, log); mntErr != nil {
 			return true, errors.Wrapf(mntErr, "failed to clean up corrupted mount point %v", mountPoint)
 		}
-		mounted = false
+		notMounted = true
 	}
 
-	if !mounted {
+	if notMounted {
 		return false, nil
 	}
 


### PR DESCRIPTION
longhorn-manager currently use k8s packages v0.23.6. mount-utils v0.23.6 does not provide IsMountPoint() and leads to the compilation failure. To fix the compatibility issue, use IsNotMountPoint() instead.

Longhorn/longhorn#3599