### PR TITLE
Fix misleading error messages     

### DIFF
--- a/list_inspect_test.go
+++ b/list_inspect_test.go
@@ -46,10 +46,6 @@ func (m *mockStoreDriver) GetURL() string {
 	return m.destURL
 }
 
-func (m *mockStoreDriver) updatePath(path string) string {
-	return ""
-}
-
 func (m *mockStoreDriver) List(listPath string) ([]string, error) {
 	defer time.Sleep(m.delay)
 

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -57,7 +57,7 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 	}
 	b.path = u.Path
 	if b.service.Bucket == "" || b.path == "" {
-		return nil, fmt.Errorf("Invalid URL. Must be either s3://bucket@region/path/, or s3://bucket/path")
+		return nil, fmt.Errorf("invalid URL. Must be either s3://bucket@region/path/, or s3://bucket/path")
 	}
 
 	// add custom ca to http client that is used by s3 service

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -205,7 +204,7 @@ func (s *TestSuite) randomChange(data []byte, offset, length int64) {
 func (s *TestSuite) SetUpSuite(c *C) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	dir, err := ioutil.TempDir("", "backupstore-test")
+	dir, err := os.MkdirTemp("", "backupstore-test")
 	c.Assert(err, IsNil)
 
 	s.BasePath = dir
@@ -314,7 +313,7 @@ func (s *TestSuite) TestBackupBasic(c *C) {
 					CreatedTime: util.Now(),
 				})
 
-			err := ioutil.WriteFile(snapName, data, 0600)
+			err := os.WriteFile(snapName, data, 0600)
 			c.Assert(err, IsNil)
 
 			s.randomChange(data, int64(i)*blockSize, 10)

--- a/test/deltablock_test.go
+++ b/test/deltablock_test.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strconv"
 
 	. "gopkg.in/check.v1"
@@ -48,7 +48,7 @@ func (s *TestSuite) TestDeleteDeltaBlockBackup(c *C) {
 				},
 			)
 
-			err := ioutil.WriteFile(snapName, data, 0600)
+			err := os.WriteFile(snapName, data, 0600)
 			c.Assert(err, IsNil)
 
 			s.randomChange(data, int64(0)*blockSize, 10)

--- a/util/util.go
+++ b/util/util.go
@@ -110,7 +110,7 @@ func DecompressAndVerify(method string, src io.Reader, checksum string) (io.Read
 		return nil, err
 	}
 	defer r.Close()
-	block, err := ioutil.ReadAll(r)
+	block, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -134,11 +134,11 @@ func newCompressionWriter(method string, buffer io.Writer) (io.WriteCloser, erro
 func newDecompressionReader(method string, r io.Reader) (io.ReadCloser, error) {
 	switch method {
 	case "none":
-		return ioutil.NopCloser(r), nil
+		return io.NopCloser(r), nil
 	case "gzip":
 		return gzip.NewReader(r)
 	case "lz4":
-		return ioutil.NopCloser(lz4.NewReader(r)), nil
+		return io.NopCloser(lz4.NewReader(r)), nil
 	default:
 		return nil, fmt.Errorf("unsupported decompression method: %v", method)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -9,16 +9,15 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
 
-	fs "github.com/google/fscrypt/filesystem"
+	"github.com/google/fscrypt/filesystem"
 	"github.com/google/uuid"
 	lz4 "github.com/pierrec/lz4/v4"
 	"github.com/pkg/errors"
@@ -289,17 +288,15 @@ func EnsureMountPoint(Kind, mountPoint string, mounter mount.Interface, log logr
 	}()
 
 	notMounted, err := mount.IsNotMountPoint(mounter, mountPoint)
-	if err != nil {
-		if strings.Contains(err.Error(), syscall.ENOENT.Error()) {
-			return false, nil
-		}
+	if err == fs.ErrNotExist {
+		return false, nil
 	}
 
 	IsCorruptedMnt := mount.IsCorruptedMnt(err)
 	if !IsCorruptedMnt {
-		log.Warnf("Mount point %v is trying reading dir to make sure it is healthy", mountPoint)
-		if _, readErr := ioutil.ReadDir(mountPoint); readErr != nil {
-			log.WithError(readErr).Warnf("Mount point %v was identified as corrupt by ReadDir", mountPoint)
+		log.Warnf("Trying reading mount point %v to make sure it is healthy", mountPoint)
+		if _, readErr := os.ReadDir(mountPoint); readErr != nil {
+			log.WithError(readErr).Warnf("Mount point %v was identified as corrupted by ReadDir", mountPoint)
 			IsCorruptedMnt = true
 		}
 	}
@@ -316,7 +313,7 @@ func EnsureMountPoint(Kind, mountPoint string, mounter mount.Interface, log logr
 		return false, nil
 	}
 
-	mnt, err := fs.GetMount(mountPoint)
+	mnt, err := filesystem.GetMount(mountPoint)
 	if err != nil {
 		return true, errors.Wrapf(err, "failed to get mount for %v", mountPoint)
 	}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os/exec"
 	"path/filepath"
@@ -70,7 +70,7 @@ func (s *TestSuite) TestCompress(c *C) {
 		decompressed, err := DecompressAndVerify(compressionMethod, compressed, checksum)
 		c.Assert(err, IsNil)
 
-		result, err := ioutil.ReadAll(decompressed)
+		result, err := io.ReadAll(decompressed)
 		c.Assert(err, IsNil)
 
 		c.Assert(result, DeepEquals, data)


### PR DESCRIPTION
If the mount point doesn't exist, the check for syscall.ENOENT.Error() will fail because the error message returned by mount.IsNotMountPoint is different. Although this won't introduce bugs and the mount point can be created in the end, the error message might be misleading for users.

Also replace the deprecated functions from io/util with others, because [staticcheck](https://staticcheck.io/) doesn't like them.
    
Longhorn/longhorn#5630