### PR TITLE
Fix wrong mounter initialization

### DIFF
--- a/cifs/cifs.go
+++ b/cifs/cifs.go
@@ -88,7 +88,7 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 }
 
 func (b *BackupStoreDriver) mount() error {
-	mounter := mount.New(b.mountDir)
+	mounter := mount.New("")
 
 	mounted, err := util.EnsureMountPoint(KIND, b.mountDir, mounter, log)
 	if err != nil {

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -85,7 +85,7 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 }
 
 func (b *BackupStoreDriver) mount() error {
-	mounter := mount.New(b.mountDir)
+	mounter := mount.New("")
 
 	mounted, err := util.EnsureMountPoint(KIND, b.mountDir, mounter, log)
 	if err != nil {


### PR DESCRIPTION
The parameter mounterPath of mount.New(...) is the path to directory contianing a customized mount command. Should leave it as empty for using the system mount command.

Longhorn/longhorn#3599