### PR TITLE
backup: introduce "starting" state

### DIFF
--- a/deltablock.go
+++ b/deltablock.go
@@ -81,7 +81,7 @@ type DeltaBlockBackupOperations interface {
 	OpenSnapshot(id, volumeID string) error
 	ReadSnapshot(id, volumeID string, start int64, data []byte) error
 	CloseSnapshot(id, volumeID string) error
-	UpdateBackupStatus(id, volumeID string, backupProgress int, backupURL string, err string) error
+	UpdateBackupStatus(id, volumeID string, backupState string, backupProgress int, backupURL string, err string) error
 }
 
 type DeltaRestoreOperations interface {
@@ -102,16 +102,23 @@ const (
 
 func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 	if config == nil {
-		return "", false, fmt.Errorf("invalid empty config for backup")
+		return "", false, fmt.Errorf("BUG: invalid empty config for backup")
 	}
-
 	volume := config.Volume
 	snapshot := config.Snapshot
 	destURL := config.DestURL
 	deltaOps := config.DeltaOps
 	if deltaOps == nil {
-		return "", false, fmt.Errorf("missing DeltaBlockBackupOperations")
+		return "", false, fmt.Errorf("BUG: missing DeltaBlockBackupOperations")
 	}
+
+	var err error
+
+	defer func() {
+		if err != nil {
+			deltaOps.UpdateBackupStatus(snapshot.Name, volume.Name, string(ProgressStateError), 0, "", err.Error())
+		}
+	}()
 
 	bsDriver, err := GetBackupStoreDriver(destURL)
 	if err != nil {
@@ -231,9 +238,9 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 		defer lock.Unlock()
 
 		if progress, backup, err := performBackup(config, delta, deltaBackup, backupRequest.lastBackup, bsDriver); err != nil {
-			deltaOps.UpdateBackupStatus(snapshot.Name, volume.Name, progress, "", err.Error())
+			deltaOps.UpdateBackupStatus(snapshot.Name, volume.Name, string(ProgressStateInProgress), progress, "", err.Error())
 		} else {
-			deltaOps.UpdateBackupStatus(snapshot.Name, volume.Name, progress, backup, "")
+			deltaOps.UpdateBackupStatus(snapshot.Name, volume.Name, string(ProgressStateInProgress), progress, backup, "")
 		}
 	}()
 	return deltaBackup.Name, backupRequest.isIncrementalBackup(), nil
@@ -242,7 +249,6 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, bool, error) {
 // performBackup if lastBackup is present we will do an incremental backup
 func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Backup, lastBackup *Backup,
 	bsDriver BackupStoreDriver) (int, string, error) {
-
 	// create an in progress backup config file
 	if err := saveBackup(&Backup{Name: deltaBackup.Name, VolumeName: deltaBackup.VolumeName,
 		CreatedTime: ""}, bsDriver); err != nil {
@@ -301,7 +307,7 @@ func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Back
 			deltaBackup.Blocks = append(deltaBackup.Blocks, blockMapping)
 		}
 		progress = int((float64(m+1) / float64(mCounts)) * PROGRESS_PERCENTAGE_BACKUP_SNAPSHOT)
-		deltaOps.UpdateBackupStatus(snapshot.Name, volume.Name, progress, "", "")
+		deltaOps.UpdateBackupStatus(snapshot.Name, volume.Name, string(ProgressStateInProgress), progress, "", "")
 	}
 
 	log.WithFields(logrus.Fields{

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -56,6 +56,7 @@ type RawFileVolume struct {
 	lock            sync.Mutex
 	v               backupstore.Volume
 	Snapshots       []backupstore.Snapshot
+	BackupState     string
 	BackupProgress  int
 	BackupError     string
 	BackupURL       string
@@ -63,8 +64,9 @@ type RawFileVolume struct {
 	RestoreError    error
 }
 
-func (r *RawFileVolume) UpdateBackupStatus(id, volumeID string, backupProgress int, backupURL string, backupError string) error {
+func (r *RawFileVolume) UpdateBackupStatus(id, volumeID string, backupState string, backupProgress int, backupURL string, backupError string) error {
 	r.lock.Lock()
+	r.BackupState = backupState
 	r.BackupProgress = backupProgress
 	r.BackupURL = backupURL
 	r.BackupError = backupError

--- a/types.go
+++ b/types.go
@@ -1,5 +1,14 @@
 package backupstore
 
+type ProgressState string
+
+const (
+	ProgressStateStarting   = ProgressState("starting")
+	ProgressStateInProgress = ProgressState("in_progress")
+	ProgressStateComplete   = ProgressState("complete")
+	ProgressStateError      = ProgressState("error")
+)
+
 type Mapping struct {
 	Offset int64
 	Size   int64


### PR DESCRIPTION
To make the backup state machine more clear, this commit introduces a new "starting" state to the existing "in_progress," "complete," and "error" states. Previously, a backup task consisted of preparation, backupstore initialization, and backup execution, with "in_progress" starting from backup execution. However, this meant that any stuck caused by an NFS connection during backupstore initialization could not be detected by the Longhorn manager. With the new "starting" state, the backup process will have a more complete state machine, ensuring better tracking and monitoring of the backup process.

Longhorn/longhorn#5662