### PR TITLE
Fix build failure on s390x

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -331,7 +331,7 @@ func EnsureMountPoint(Kind, mountPoint string, mounter mount.Interface, log logr
 		return true, errors.Wrapf(err, "failed to statfs for mount point %v", mountPoint)
 	}
 
-	kind, err := fstypeToKind(stat.Type)
+	kind, err := fstypeToKind(int64(stat.Type))
 	if err != nil {
 		return true, errors.Wrapf(err, "failed to get kind for mount point %v", mountPoint)
 	}


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/5856

```
vendor/github.com/longhorn/backupstore/util/util.go:334:28: cannot use stat.Type (variable of type uint32) as int64 value in argument to fstypeToKind
```