### PR TITLE
feat(backing): backingimage backup support

### DIFF
--- a/backupbackingimage/backupbackingimage.go
+++ b/backupbackingimage/backupbackingimage.go
@@ -1,0 +1,608 @@
+package backupbackingimage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/longhorn/backupstore"
+	"github.com/longhorn/backupstore/common"
+	"github.com/longhorn/backupstore/util"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type BackupBackingImage struct {
+	sync.Mutex
+
+	Name              string
+	Size              int64 `json:",string"`
+	BlockCount        int64 `json:",string"`
+	Checksum          string
+	Labels            map[string]string
+	CompressionMethod string
+	CreatedTime       string
+	CompleteTime      string
+
+	ProcessingBlocks *common.ProcessingBlocks
+
+	Blocks []common.BlockMapping `json:",omitempty"`
+}
+
+type BackupConfig struct {
+	Name            string
+	DestURL         string
+	ConcurrentLimit int32
+}
+
+type RestoreConfig struct {
+	BackupURL       string
+	Filename        string
+	ConcurrentLimit int32
+}
+
+type BackupStatus interface {
+	ReadFile(start int64, data []byte) error
+	CloseFile() error
+	Update(state string, progress int, backupURL string, err string) error
+}
+
+type RestoreStatus interface {
+	UpdateRestoreProgress(progress int, err error)
+}
+
+func CreateBackingImageBackup(config *BackupConfig, backupBackingImage *BackupBackingImage, backupStatus BackupStatus, mappings *common.Mappings) (err error) {
+	log := backupstore.GetLog()
+	if config == nil || backupStatus == nil {
+		return fmt.Errorf("invalid empty config or backupStatus for backup")
+	}
+
+	defer func() {
+		if err != nil {
+			backupStatus.Update(string(common.ProgressStateError), 0, "", err.Error())
+		}
+	}()
+
+	bsDriver, err := backupstore.GetBackupStoreDriver(config.DestURL)
+	if err != nil {
+		return err
+	}
+
+	lock, err := backupstore.New(bsDriver, config.Name, backupstore.BACKUP_LOCK)
+	if err != nil {
+		return err
+	}
+
+	defer lock.Unlock()
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+
+	if err := addBackingImage(bsDriver, backupBackingImage); err != nil {
+		return err
+	}
+
+	backupBackingImage, err = loadBackingImage(bsDriver, backupBackingImage.Name)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Creating backup backing image")
+
+	backupBackingImage.Blocks = []common.BlockMapping{}
+	backupBackingImage.ProcessingBlocks = &common.ProcessingBlocks{
+		Blocks: map[string][]*common.BlockMapping{},
+	}
+
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+
+	go func() {
+		defer backupStatus.CloseFile()
+		defer lock.Unlock()
+
+		backupStatus.Update(string(common.ProgressStateInProgress), 0, "", "")
+
+		if progress, backupURL, err := performBackup(bsDriver, config, backupBackingImage, backupStatus, mappings); err != nil {
+			log.WithError(err).Errorf("Failed to perform backup for backing image %v", backupBackingImage.Name)
+			backupStatus.Update(string(common.ProgressStateInProgress), progress, "", err.Error())
+		} else {
+			backupStatus.Update(string(common.ProgressStateInProgress), progress, backupURL, "")
+		}
+	}()
+
+	return nil
+}
+
+func performBackup(bsDriver backupstore.BackupStoreDriver, config *BackupConfig,
+	backupBackingImage *BackupBackingImage, backupStatus BackupStatus, mappings *common.Mappings) (int, string, error) {
+	log := backupstore.GetLog()
+	destURL := config.DestURL
+	concurrentLimit := config.ConcurrentLimit
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	totalBlockCounts, err := getTotalBackupBlockCounts(mappings)
+	if err != nil {
+		return 0, "", err
+	}
+	log.Infof("Creating backup backing image consisting of %v mappings and %v blocks", len(mappings.Mappings), totalBlockCounts)
+
+	progress := &common.Progress{
+		TotalBlockCounts: totalBlockCounts,
+	}
+
+	mappingChan, errChan := common.PopulateMappings(bsDriver, mappings)
+
+	errorChans := []<-chan error{errChan}
+	for i := 0; i < int(concurrentLimit); i++ {
+		errorChans = append(errorChans, backupMappings(ctx, bsDriver, config, backupBackingImage, backupStatus, mappings.BlockSize, progress, mappingChan))
+	}
+	mergedErrChan := common.MergeErrorChannels(ctx, errorChans...)
+	err = <-mergedErrChan
+	if err != nil {
+		return progress.Progress, "", errors.Wrapf(err, "failed to backup backing image %v", backupBackingImage.Name)
+	}
+
+	backupBackingImage.Blocks = common.SortBackupBlocks(backupBackingImage.Blocks, backupBackingImage.Size, mappings.BlockSize)
+	backupBackingImage.CompleteTime = util.Now()
+	backupBackingImage.BlockCount = totalBlockCounts
+	if err := saveBackingImage(bsDriver, backupBackingImage); err != nil {
+		return progress.Progress, "", err
+	}
+
+	return common.ProgressPercentageBackupTotal, EncodeBackupBackingImageURL(config.Name, destURL), nil
+}
+
+func backupMappings(ctx context.Context, bsDriver backupstore.BackupStoreDriver,
+	config *BackupConfig, backupBackingImage *BackupBackingImage, backupStatus BackupStatus,
+	blockSize int64, progress *common.Progress, in <-chan common.Mapping) <-chan error {
+
+	errChan := make(chan error, 1)
+	go func() {
+		defer close(errChan)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case mapping, open := <-in:
+				if !open {
+					return
+				}
+
+				if err := backupMapping(bsDriver, config, backupBackingImage, backupStatus, blockSize, mapping, progress); err != nil {
+					errChan <- err
+					return
+				}
+			}
+		}
+	}()
+
+	return errChan
+}
+
+func backupMapping(bsDriver backupstore.BackupStoreDriver,
+	config *BackupConfig, backupBackingImage *BackupBackingImage, backupStatus BackupStatus,
+	blockSize int64, mapping common.Mapping, progress *common.Progress) error {
+
+	log := backupstore.GetLog()
+	block := make([]byte, mapping.Size)
+
+	if err := backupStatus.ReadFile(mapping.Offset, block); err != nil {
+		log.WithError(err).Errorf("Failed to read backing image %v block at offset %v size %v", backupBackingImage.Name, mapping.Offset, len(block))
+		return err
+	}
+
+	if err := backupBlock(bsDriver, config, backupBackingImage, backupStatus, mapping.Offset, block, progress); err != nil {
+		logrus.WithError(err).Errorf("Failed to back up backing image %v block at offset %v size %v", backupBackingImage.Name, mapping.Offset, len(block))
+		return err
+	}
+
+	return nil
+}
+
+func backupBlock(bsDriver backupstore.BackupStoreDriver,
+	config *BackupConfig, backupBackingImage *BackupBackingImage, backupStatus BackupStatus,
+	offset int64, block []byte, progress *common.Progress) error {
+
+	var err error
+	newBlock := false
+
+	checksum := util.GetChecksum(block)
+
+	if isBlockBeingProcessed(backupBackingImage, offset, checksum) {
+		return nil
+	}
+
+	defer func() {
+		if err != nil {
+			return
+		}
+		backupBackingImage.Lock()
+		defer backupBackingImage.Unlock()
+		updateBlocksAndProgress(backupBackingImage, progress, checksum, newBlock)
+		backupStatus.Update(string(common.ProgressStateInProgress), progress.Progress, "", "")
+	}()
+
+	// skip if block already exists
+	blkFile := getBackingImageBlockFilePath(checksum)
+	if bsDriver.FileExists(blkFile) {
+		return nil
+	}
+
+	newBlock = true
+	rs, err := util.CompressData(backupBackingImage.CompressionMethod, block)
+	if err != nil {
+		return err
+	}
+
+	return bsDriver.Write(blkFile, rs)
+}
+
+func isBlockBeingProcessed(backupBackingImage *BackupBackingImage, offset int64, checksum string) bool {
+	processingBlocks := backupBackingImage.ProcessingBlocks
+
+	processingBlocks.Lock()
+	defer processingBlocks.Unlock()
+
+	blockInfo := &common.BlockMapping{
+		Offset:        offset,
+		BlockChecksum: checksum,
+	}
+	if _, ok := processingBlocks.Blocks[checksum]; ok {
+		processingBlocks.Blocks[checksum] = append(processingBlocks.Blocks[checksum], blockInfo)
+		return true
+	}
+
+	processingBlocks.Blocks[checksum] = []*common.BlockMapping{blockInfo}
+	return false
+}
+
+func updateBlocksAndProgress(backupBackingImage *BackupBackingImage, progress *common.Progress, checksum string, newBlock bool) {
+	processingBlocks := backupBackingImage.ProcessingBlocks
+
+	processingBlocks.Lock()
+	defer processingBlocks.Unlock()
+
+	blocks := processingBlocks.Blocks[checksum]
+	for _, block := range blocks {
+		backupBackingImage.Blocks = append(backupBackingImage.Blocks, *block)
+	}
+
+	// Update progress
+	func() {
+		progress.Lock()
+		defer progress.Unlock()
+
+		if newBlock {
+			progress.NewBlockCounts++
+		}
+		progress.ProcessedBlockCounts += int64(len(blocks))
+		progress.Progress = common.GetProgress(progress.TotalBlockCounts, progress.ProcessedBlockCounts)
+	}()
+
+	delete(processingBlocks.Blocks, checksum)
+}
+
+func RestoreBackingImageBackup(config *RestoreConfig, restoreStatus RestoreStatus) error {
+	if config == nil || restoreStatus == nil {
+		return fmt.Errorf("invalid empty config or restoreStatus for restore")
+	}
+
+	backingImageFilePath := config.Filename
+	backupURL := config.BackupURL
+	concurrentLimit := config.ConcurrentLimit
+
+	bsDriver, err := backupstore.GetBackupStoreDriver(backupURL)
+	if err != nil {
+		return err
+	}
+
+	backingImageName, _, err := DecodeBackupBackingImageURL(backupURL)
+	if err != nil {
+		return err
+	}
+
+	lock, err := backupstore.New(bsDriver, backingImageName, backupstore.RESTORE_LOCK)
+	if err != nil {
+		return err
+	}
+
+	defer lock.Unlock()
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+
+	backupBackingImage, err := loadBackingImage(bsDriver, backingImageName)
+	if err != nil {
+		return errors.Wrapf(err, "backing image %v doesn't exist in backup store", backingImageName)
+	}
+
+	if backupBackingImage.Size == 0 {
+		return fmt.Errorf("read invalid backing image size %v", backupBackingImage.Size)
+	}
+
+	backingImageFile, err := checkBackingImageFile(backingImageFilePath, backupBackingImage)
+	if err != nil {
+		return errors.Wrapf(err, "check backing image file failed")
+	}
+
+	defer func() {
+		if err != nil {
+			_ = backingImageFile.Close()
+		}
+	}()
+
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+
+	go func() {
+		defer backingImageFile.Close()
+		defer lock.Unlock()
+
+		progress := &common.Progress{
+			TotalBlockCounts: int64(len(backupBackingImage.Blocks)),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		blockChan, errChan := common.PopulateBlocksForFullRestore(backupBackingImage.Blocks, backupBackingImage.CompressionMethod)
+		errorChans := []<-chan error{errChan}
+		for i := 0; i < int(concurrentLimit); i++ {
+			errorChans = append(errorChans, restoreBlocks(ctx, bsDriver, backingImageFilePath, blockChan, progress, restoreStatus))
+		}
+
+		mergedErrChan := common.MergeErrorChannels(ctx, errorChans...)
+		err = <-mergedErrChan
+		if err != nil {
+			restoreStatus.UpdateRestoreProgress(int(progress.ProcessedBlockCounts)*backupstore.DEFAULT_BLOCK_SIZE, err)
+			return
+		}
+
+		restoreStatus.UpdateRestoreProgress(int(backupBackingImage.Size), nil)
+	}()
+
+	return nil
+}
+
+func checkBackingImageFile(backingImageFilePath string, backupBackingImage *BackupBackingImage) (*os.File, error) {
+	if _, err := os.Stat(backingImageFilePath); err == nil {
+		logrus.Warnf("File %s for the restore exists, will remove and re-create it", backingImageFilePath)
+		if err := os.RemoveAll(backingImageFilePath); err != nil {
+			return nil, errors.Wrapf(err, "failed to clean up the existing file %v before restore", backingImageFilePath)
+		}
+	}
+
+	backingImageFile, err := os.Create(backingImageFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil {
+			_ = backingImageFile.Close()
+		}
+	}()
+
+	stat, err := backingImageFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	// This pre-truncate is to ensure the XFS speculatively
+	// preallocates post-EOF blocks get reclaimed when volDev is
+	// closed.
+	// https://github.com/longhorn/longhorn/issues/2503
+	// We want to truncate regular files, but not device
+	if stat.Mode()&os.ModeType == 0 {
+		if err := backingImageFile.Truncate(backupBackingImage.Size); err != nil {
+			errors.Wrapf(err, "failed to truncate backing image")
+			return nil, err
+		}
+	}
+
+	return backingImageFile, nil
+}
+
+func restoreBlocks(ctx context.Context, bsDriver backupstore.BackupStoreDriver, backingImageFilePath string, in <-chan *common.Block, progress *common.Progress, restoreStatus RestoreStatus) <-chan error {
+	errChan := make(chan error, 1)
+
+	go func() {
+		defer close(errChan)
+
+		backingImageFile, err := os.OpenFile(backingImageFilePath, os.O_RDWR, 0666)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer backingImageFile.Close()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case block, open := <-in:
+				if !open {
+					return
+				}
+
+				if err := restoreBlock(bsDriver, backingImageFile, block, progress, restoreStatus); err != nil {
+					errChan <- err
+					return
+				}
+			}
+		}
+	}()
+
+	return errChan
+}
+
+func restoreBlock(bsDriver backupstore.BackupStoreDriver, backingImageFile *os.File, block *common.Block, progress *common.Progress, restoreStatus RestoreStatus) error {
+
+	defer func() {
+		progress.Lock()
+		defer progress.Unlock()
+
+		progress.ProcessedBlockCounts++
+		progress.Progress = common.GetProgress(progress.TotalBlockCounts, progress.ProcessedBlockCounts)
+		restoreStatus.UpdateRestoreProgress(int(progress.ProcessedBlockCounts)*backupstore.DEFAULT_BLOCK_SIZE, nil)
+	}()
+
+	return restoreBlockToFile(bsDriver, backingImageFile, block.CompressionMethod,
+		common.BlockMapping{
+			Offset:        block.Offset,
+			BlockChecksum: block.BlockChecksum,
+		})
+}
+
+func restoreBlockToFile(bsDriver backupstore.BackupStoreDriver, backingImageFile *os.File, decompression string, blk common.BlockMapping) error {
+	blkFile := getBackingImageBlockFilePath(blk.BlockChecksum)
+	rc, err := bsDriver.Read(blkFile)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	r, err := util.DecompressAndVerify(decompression, rc, blk.BlockChecksum)
+	if err != nil {
+		return err
+	}
+
+	if _, err := backingImageFile.Seek(blk.Offset, 0); err != nil {
+		return err
+	}
+	_, err = io.Copy(backingImageFile, r)
+	return err
+}
+
+func RemoveBackingImageBackup(backupURL string) (err error) {
+	bsDriver, err := backupstore.GetBackupStoreDriver(backupURL)
+	if err != nil {
+		return err
+	}
+	backingImageName, _, err := DecodeBackupBackingImageURL(backupURL)
+	if err != nil {
+		return err
+	}
+	log := backupstore.GetLog()
+	log = log.WithFields(logrus.Fields{"BackingImage": backingImageName})
+
+	lock, err := backupstore.New(bsDriver, backingImageName, backupstore.DELETION_LOCK)
+	if err != nil {
+		return err
+	}
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+	defer lock.Unlock()
+
+	// If we fail to load the backup we still want to proceed with the deletion of the backup file
+	backupBackingImage, err := loadBackingImage(bsDriver, backingImageName)
+	if err != nil {
+		log.WithError(err).Warn("Failed to load to be deleted backup backing image")
+		backupBackingImage = &BackupBackingImage{
+			Name: backingImageName,
+		}
+	}
+
+	// we can delete the requested backupBackingImage immediately before GC starts
+	if err := removeBackupBackingImage(backupBackingImage, bsDriver); err != nil {
+		return err
+	}
+	log.Info("Removed backup backing image config")
+
+	blockInfos, err := getBlockInfos(bsDriver)
+	if err != nil {
+		return err
+	}
+
+	backupbackingImageNames, err := GetAllBackupBackingImageNames(bsDriver)
+	if err != nil {
+		log.WithError(err).Warn("Failed to load backup backing image names, skip block deletion")
+		return nil
+	}
+
+	canDeleteBlocks := checkAndUpdateBlockInfos(bsDriver, blockInfos, backupbackingImageNames)
+	if !canDeleteBlocks {
+		return nil
+	}
+
+	// check if there have been new backups created while we where processing
+	prevBackupBackingImageNames := backupbackingImageNames
+	backupBackingImageNames, err := GetAllBackupBackingImageNames(bsDriver)
+	if err != nil || !util.UnorderedEqual(prevBackupBackingImageNames, backupBackingImageNames) {
+		log.Info("Found new backup backing image, skip block deletion")
+		return nil
+	}
+
+	// only delete the blocks if it is safe to do so
+	if err := cleanupBlocks(bsDriver, blockInfos); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkAndUpdateBlockInfos(bsDriver backupstore.BackupStoreDriver, blockInfos map[string]*common.BlockInfo, backupbackingImageNames []string) bool {
+	log := backupstore.GetLog()
+
+	for _, name := range backupbackingImageNames {
+		backupBackingImage, err := loadBackingImage(bsDriver, name)
+		if err != nil {
+			log.WithError(err).Warn("Failed to load backup backing image, skip block deletion")
+			return false
+		}
+
+		if isBackupInProgress(backupBackingImage) {
+			log.Info("Found in progress backup backing image, skip block deletion")
+			return false
+		}
+
+		common.UpdateBlockReferenceCount(blockInfos, backupBackingImage.Blocks, bsDriver)
+	}
+	return true
+}
+
+func getBlockInfos(bsDriver backupstore.BackupStoreDriver) (map[string]*common.BlockInfo, error) {
+	blockInfos := make(map[string]*common.BlockInfo)
+	blockNames, err := getAllBlockNames(bsDriver)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range blockNames {
+		blockInfos[name] = &common.BlockInfo{
+			Checksum: name,
+			Path:     getBackingImageBlockFilePath(name),
+			Refcount: 0,
+		}
+	}
+	return blockInfos, nil
+}
+
+func cleanupBlocks(driver backupstore.BackupStoreDriver, blockMap map[string]*common.BlockInfo) error {
+	var deletionFailures []string
+	deletedBlockCount := int64(0)
+	for _, blk := range blockMap {
+		if common.IsBlockSafeToDelete(blk) {
+			if err := driver.Remove(blk.Path); err != nil {
+				deletionFailures = append(deletionFailures, blk.Checksum)
+				continue
+			}
+			deletedBlockCount++
+		}
+	}
+
+	log := backupstore.GetLog()
+	log.Infof("Removed %v blocks", deletedBlockCount)
+
+	if len(deletionFailures) > 0 {
+		return fmt.Errorf("failed to delete blocks: %v", deletionFailures)
+	}
+	return nil
+}

--- a/backupbackingimage/config.go
+++ b/backupbackingimage/config.go
@@ -1,0 +1,207 @@
+package backupbackingimage
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+
+	"github.com/longhorn/backupstore"
+	"github.com/longhorn/backupstore/common"
+	"github.com/longhorn/backupstore/util"
+	"github.com/pkg/errors"
+)
+
+const (
+	BackingImageBlockSeparateLayer1 = 2
+	BackingImageBlockSeparateLayer2 = 4
+
+	BackingImageDirectory  = "backing-images"
+	BackingImageConfigFile = "backing-image.cfg"
+
+	BlocksDirectory = "blocks"
+	BlkSuffix       = ".blk"
+)
+
+func addBackingImage(driver backupstore.BackupStoreDriver, backupBackingImage *BackupBackingImage) error {
+	log := backupstore.GetLog()
+	if backingImageExists(driver, backupBackingImage.Name) {
+		return nil
+	}
+
+	if !util.ValidateName(backupBackingImage.Name) {
+		return fmt.Errorf("invalid backing image name %v", backupBackingImage.Name)
+	}
+
+	if err := saveBackingImage(driver, backupBackingImage); err != nil {
+		return errors.Wrapf(err, "failed to add backing image %v", backupBackingImage.Name)
+	}
+
+	log.Infof("Added backupstore backing image %v", backupBackingImage.Name)
+	return nil
+}
+
+func removeBackupBackingImage(backupBackingImage *BackupBackingImage, driver backupstore.BackupStoreDriver) error {
+	log := backupstore.GetLog()
+	filePath := getBackingImageFilePath(backupBackingImage.Name)
+	if err := driver.Remove(filePath); err != nil {
+		return err
+	}
+	log.Infof("Removed %v on backupstore", filePath)
+	return nil
+}
+
+func backingImageExists(driver backupstore.BackupStoreDriver, backingImageName string) bool {
+	return driver.FileExists(getBackingImageFilePath(backingImageName))
+}
+
+func getBackingImageFilePath(backingImageName string) string {
+	backingImagePath := getBackingImagePath(backingImageName)
+	backingImageCfg := BackingImageConfigFile
+	return filepath.Join(backingImagePath, backingImageCfg)
+}
+
+func getBackingImagePath(backingImageName string) string {
+	return filepath.Join(backupstore.GetBackupstoreBase(), BackingImageDirectory, BackingImageDirectory, backingImageName) + "/"
+}
+
+func saveBackingImage(driver backupstore.BackupStoreDriver, backupBackingImage *BackupBackingImage) error {
+	return backupstore.SaveConfigInBackupStore(driver, getBackingImageFilePath(backupBackingImage.Name), backupBackingImage)
+}
+
+func loadBackingImage(driver backupstore.BackupStoreDriver, backingImageName string) (*BackupBackingImage, error) {
+	log := backupstore.GetLog()
+	backupBackingImage := &BackupBackingImage{}
+	path := getBackingImageFilePath(backingImageName)
+	if err := backupstore.LoadConfigInBackupStore(driver, path, backupBackingImage); err != nil {
+		return nil, err
+	}
+	if backupBackingImage.CompressionMethod == "" {
+		log.Infof("Fall back compression method to %v for volume %v", backupstore.LEGACY_COMPRESSION_METHOD, backupBackingImage.Name)
+		backupBackingImage.CompressionMethod = backupstore.LEGACY_COMPRESSION_METHOD
+	}
+	return backupBackingImage, nil
+}
+
+func getTotalBackupBlockCounts(mappings *common.Mappings) (int64, error) {
+	totalBlockCounts := int64(len(mappings.Mappings))
+	return totalBlockCounts, nil
+}
+
+func getBackingImageBlockFilePath(checksum string) string {
+	blockSubDirLayer1 := checksum[0:BackingImageBlockSeparateLayer1]
+	blockSubDirLayer2 := checksum[BackingImageBlockSeparateLayer1:BackingImageBlockSeparateLayer2]
+	path := filepath.Join(getBackingImageBlockPath(), blockSubDirLayer1, blockSubDirLayer2)
+	fileName := checksum + BlkSuffix
+
+	return filepath.Join(path, fileName)
+}
+
+func getBackingImageBlockPath() string {
+	return filepath.Join(backupstore.GetBackupstoreBase(), BackingImageDirectory, BlocksDirectory) + "/"
+}
+
+func EncodeBackupBackingImageURL(backingImageName, destURL string) string {
+	v := url.Values{}
+	v.Add("backingImage", backingImageName)
+	return destURL + "?" + v.Encode()
+}
+
+func DecodeBackupBackingImageURL(backupURL string) (string, string, error) {
+	u, err := url.Parse(backupURL)
+	if err != nil {
+		return "", "", err
+	}
+	v := u.Query()
+	backingImageName := v.Get("backingImage")
+	if !util.ValidateName(backingImageName) {
+		return "", "", fmt.Errorf("invalid backing image name parsed: %v", backingImageName)
+	}
+	u.RawQuery = ""
+	destURL := u.String()
+	return backingImageName, destURL, nil
+}
+
+func GetAllBackupBackingImageNames(driver backupstore.BackupStoreDriver) ([]string, error) {
+	result := []string{}
+	backingImageConfigBase := filepath.Join(backupstore.GetBackupstoreBase(), BackingImageDirectory, BackingImageDirectory) + "/"
+	nameList, err := driver.List(backingImageConfigBase)
+	if err != nil {
+		return result, nil
+	}
+	return nameList, nil
+}
+
+func getAllBlockNames(driver backupstore.BackupStoreDriver) ([]string, error) {
+	names := []string{}
+	blockPathBase := getBackingImageBlockPath()
+	lv1Dirs, err := driver.List(blockPathBase)
+	// Directory doesn't exist
+	if err != nil {
+		return names, nil
+	}
+	for _, lv1 := range lv1Dirs {
+		lv1Path := filepath.Join(blockPathBase, lv1)
+		lv2Dirs, err := driver.List(lv1Path)
+		if err != nil {
+			return nil, err
+		}
+		for _, lv2 := range lv2Dirs {
+			lv2Path := filepath.Join(lv1Path, lv2)
+			blockNames, err := driver.List(lv2Path)
+			if err != nil {
+				return nil, err
+			}
+			names = append(names, blockNames...)
+		}
+	}
+
+	return util.ExtractNames(names, "", BlkSuffix), nil
+}
+
+func isBackupInProgress(backupBackingImage *BackupBackingImage) bool {
+	return backupBackingImage != nil && backupBackingImage.CompleteTime == ""
+}
+
+type BackupInfo struct {
+	Name              string
+	URL               string
+	CompleteAt        string
+	Size              int64 `json:",string"`
+	Checksum          string
+	Labels            map[string]string
+	CompressionMethod string `json:",omitempty"`
+}
+
+func InspectBackupBackingImage(backupURL string) (*BackupInfo, error) {
+	backupBackingImageName, destURL, err := DecodeBackupBackingImageURL(backupURL)
+	if err != nil {
+		return nil, err
+	}
+
+	bsDriver, err := backupstore.GetBackupStoreDriver(destURL)
+	if err != nil {
+		return nil, err
+	}
+
+	backupBackingImage, err := loadBackingImage(bsDriver, backupBackingImageName)
+	if err != nil {
+		return nil, err
+	} else if isBackupInProgress(backupBackingImage) {
+		// for now we don't return in progress backup backing image to the ui
+		return nil, fmt.Errorf("backup backing image %v is still in progress", backupBackingImage.Name)
+	}
+
+	return fillFullBackupBackingImageInfo(backupBackingImage, bsDriver.GetURL()), nil
+}
+
+func fillFullBackupBackingImageInfo(backupBackingImage *BackupBackingImage, destURL string) *BackupInfo {
+	return &BackupInfo{
+		Name:              backupBackingImage.Name,
+		URL:               EncodeBackupBackingImageURL(backupBackingImage.Name, destURL),
+		CompleteAt:        backupBackingImage.CompleteTime,
+		Size:              backupBackingImage.Size,
+		Checksum:          backupBackingImage.Checksum,
+		Labels:            backupBackingImage.Labels,
+		CompressionMethod: backupBackingImage.CompressionMethod,
+	}
+}

--- a/cmd/backup_backing_image.go
+++ b/cmd/backup_backing_image.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
+	"github.com/longhorn/backupstore"
+	"github.com/longhorn/backupstore/backupbackingimage"
+	"github.com/longhorn/backupstore/util"
+)
+
+func BackupBackingImageListCmd() cli.Command {
+	return cli.Command{
+		Name:   "ls-backing-image",
+		Usage:  "list backup backing images in backupstore: ls-backing-image <dest>",
+		Action: cmdBackupBackingImageList,
+	}
+}
+
+func cmdBackupBackingImageList(c *cli.Context) {
+	if err := doBackupBackingImageList(c); err != nil {
+		panic(err)
+	}
+}
+
+func doBackupBackingImageList(c *cli.Context) error {
+	var err error
+
+	if c.NArg() == 0 {
+		return RequiredMissingError("dest URL")
+	}
+	destURL := c.Args()[0]
+	if destURL == "" {
+		return RequiredMissingError("dest URL")
+	}
+
+	bsdriver, err := backupstore.GetBackupStoreDriver(destURL)
+	if err != nil {
+		return err
+	}
+	list, err := backupbackingimage.GetAllBackupBackingImageNames(bsdriver)
+	if err != nil {
+		return err
+	}
+
+	data, err := ResponseOutput(list)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func InspectBackingImageCmd() cli.Command {
+	return cli.Command{
+		Name:  "inspect-backing-image",
+		Usage: "output the backup backing image config from the object store: inspect-backing-image <backup-url>",
+		Action: func(c *cli.Context) {
+			if err := inspectBackupBackingImageConfig(c); err != nil {
+				logrus.WithError(err).Fatalf("Failed to run inspect-backing-image command")
+			}
+		},
+	}
+}
+
+func inspectBackupBackingImageConfig(c *cli.Context) error {
+	if c.NArg() == 0 {
+		return fmt.Errorf("missing required parameter for backup backing image URL")
+	}
+
+	if c.NArg() == 0 {
+		return RequiredMissingError("backup-url")
+	}
+	backupURL := c.Args()[0]
+	if backupURL == "" {
+		return RequiredMissingError("backup-url")
+	}
+	backupURL = util.UnescapeURL(backupURL)
+
+	info, err := backupbackingimage.InspectBackupBackingImage(backupURL)
+	if err != nil {
+		return err
+	}
+	data, err := ResponseOutput(info)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+	return nil
+}
+
+func BackupBackingImageRemoveCmd() cli.Command {
+	return cli.Command{
+		Name:   "rm-backing-image",
+		Usage:  "remove a backup backing image in objectstore",
+		Action: cmdBackupBackingImageRemove,
+	}
+}
+
+func cmdBackupBackingImageRemove(c *cli.Context) {
+	if err := doBackupBackingImageRemove(c); err != nil {
+		panic(err)
+	}
+}
+
+func doBackupBackingImageRemove(c *cli.Context) error {
+	if c.NArg() == 0 {
+		return RequiredMissingError("dest URL")
+	}
+	destURL := c.Args()[0]
+	if destURL == "" {
+		return RequiredMissingError("dest URL")
+	}
+
+	destURL = util.UnescapeURL(destURL)
+	err := backupbackingimage.RemoveBackingImageBackup(destURL)
+	return err
+}

--- a/common/backup.go
+++ b/common/backup.go
@@ -1,0 +1,194 @@
+package common
+
+import (
+	"context"
+	"sync"
+
+	"github.com/longhorn/backupstore"
+)
+
+type ProgressState string
+
+const (
+	ProgressStateInProgress = ProgressState("in_progress")
+	ProgressStateComplete   = ProgressState("complete")
+	ProgressStateError      = ProgressState("error")
+)
+
+const (
+	ProgressPercentageBackup      = 95
+	ProgressPercentageBackupTotal = 100
+)
+
+type Mapping struct {
+	Offset int64
+	Size   int64
+}
+
+type Mappings struct {
+	Mappings  []Mapping
+	BlockSize int64
+}
+
+type MessageType string
+
+const (
+	MessageTypeError = MessageType("error")
+)
+
+type JobResult struct {
+	payload interface{}
+	err     error
+}
+
+type BlockMapping struct {
+	Offset        int64
+	BlockChecksum string
+}
+
+type BlockInfo struct {
+	Checksum string
+	Path     string
+	Refcount int
+}
+
+type Block struct {
+	Offset            int64
+	BlockChecksum     string
+	CompressionMethod string
+	IsZeroBlock       bool
+}
+
+type ProcessingBlocks struct {
+	sync.Mutex
+	Blocks map[string][]*BlockMapping
+}
+
+type Progress struct {
+	sync.Mutex
+
+	TotalBlockCounts     int64
+	ProcessedBlockCounts int64
+	NewBlockCounts       int64
+
+	Progress int
+}
+
+func PopulateMappings(bsDriver backupstore.BackupStoreDriver, mappings *Mappings) (<-chan Mapping, <-chan error) {
+	mappingChan := make(chan Mapping, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		defer close(mappingChan)
+		defer close(errChan)
+
+		for _, mapping := range mappings.Mappings {
+			mappingChan <- mapping
+		}
+	}()
+
+	return mappingChan, errChan
+}
+
+func PopulateBlocksForFullRestore(blocks []BlockMapping, compressionMethod string) (<-chan *Block, <-chan error) {
+	blockChan := make(chan *Block, 10)
+	errChan := make(chan error, 1)
+
+	go func() {
+		defer close(blockChan)
+		defer close(errChan)
+
+		for _, block := range blocks {
+			blockChan <- &Block{
+				Offset:            block.Offset,
+				BlockChecksum:     block.BlockChecksum,
+				CompressionMethod: compressionMethod,
+			}
+		}
+	}()
+
+	return blockChan, errChan
+}
+
+// MergeErrorChannels will merge all error channels into a single error out channel.
+// the error out channel will be closed once the ctx is done or all error channels are closed
+// if there is an error on one of the incoming channels the error will be relayed.
+func MergeErrorChannels(ctx context.Context, channels ...<-chan error) <-chan error {
+	var wg sync.WaitGroup
+	wg.Add(len(channels))
+
+	out := make(chan error, len(channels))
+	output := func(c <-chan error) {
+		defer wg.Done()
+		select {
+		case err, ok := <-c:
+			if ok {
+				out <- err
+			}
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	for _, c := range channels {
+		go output(c)
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+	return out
+}
+
+func GetProgress(total, processed int64) int {
+	return int((float64(processed+1) / float64(total)) * ProgressPercentageBackup)
+}
+
+func SortBackupBlocks(blocks []BlockMapping, size, blockSize int64) []BlockMapping {
+	blocksNum := size / blockSize
+	if size%blockSize > 0 {
+		blocksNum++
+	}
+	sortedBlocks := make([]string, blocksNum)
+	for _, block := range blocks {
+		i := block.Offset / blockSize
+		sortedBlocks[i] = block.BlockChecksum
+	}
+
+	blockMappings := []BlockMapping{}
+	for i, checksum := range sortedBlocks {
+		if checksum != "" {
+			blockMappings = append(blockMappings, BlockMapping{
+				Offset:        int64(i) * blockSize,
+				BlockChecksum: checksum,
+			})
+		}
+	}
+
+	return blockMappings
+}
+
+func UpdateBlockReferenceCount(blockInfos map[string]*BlockInfo, blocks []BlockMapping, driver backupstore.BackupStoreDriver) {
+	for _, block := range blocks {
+		info, known := blockInfos[block.BlockChecksum]
+		if !known {
+			info = &BlockInfo{Checksum: block.BlockChecksum}
+			blockInfos[block.BlockChecksum] = info
+		}
+		info.Refcount++
+	}
+}
+
+func IsBlockSafeToDelete(blk *BlockInfo) bool {
+	return isBlockPresent(blk) && !isBlockReferenced(blk)
+}
+
+func isBlockPresent(blk *BlockInfo) bool {
+	return blk != nil && blk.Path != ""
+}
+
+func isBlockReferenced(blk *BlockInfo) bool {
+	return blk != nil && blk.Refcount > 0
+}

--- a/common/backup.go
+++ b/common/backup.go
@@ -36,11 +36,6 @@ const (
 	MessageTypeError = MessageType("error")
 )
 
-type JobResult struct {
-	payload interface{}
-	err     error
-}
-
 type BlockMapping struct {
 	Offset        int64
 	BlockChecksum string

--- a/types/types.go
+++ b/types/types.go
@@ -49,3 +49,7 @@ type JobResult struct {
 	Payload interface{}
 	Err     error
 }
+
+const (
+	BackupBackingImageLockName = "BACKINGIMAGE"
+)


### PR DESCRIPTION
ref: [longhorn/longhorn#4165](https://github.com/longhorn/longhorn/issues/4165)

For BackingImage backup, we implemented 3 main functions
1. **CreateBackingImageBackup()**
    - with BackupBackingImageStatus interface, we can read the BackingImage data and upload it as block.
2. **RestoreBackingImageBackup()**
    - with RestoreBackingImageStatus interface, we can update the sync_file progress in `backing-image-data-source`
3. **RemoveBackingImageBackup()**

and 3 commands
- **ls-backing-image**: list all backing image names in the backupstore, so we can create the CR with `backup_target_controller`
- **inspect-backing-image**: get the info of the backup backing image, so we can sync the info the CR in the new cluster
- **rm-backing-image**: we can't implement this as grpc in `backing-image-manager`, since there might have no `backing-image-manager` pod in the cluster, so deletion can be only implemented as command and be used in the controller.
