### PR TITLE
Object Storage (LEP 20230430)

### DIFF
--- a/backupstore.go
+++ b/backupstore.go
@@ -23,6 +23,7 @@ type Volume struct {
 	CompressionMethod    string `json:",string"`
 	StorageClassName     string `json:",string"`
 	BackendStoreDriver   string `json:",string"`
+	ObjectStoreBackup    string `json:",string"`
 }
 
 type Snapshot struct {
@@ -46,6 +47,7 @@ type Backup struct {
 	Labels            map[string]string
 	IsIncremental     bool
 	CompressionMethod string
+	ObjectStoreBackup string
 
 	ProcessingBlocks *ProcessingBlocks
 

--- a/deltablock.go
+++ b/deltablock.go
@@ -532,6 +532,7 @@ func performBackup(bsDriver BackupStoreDriver, config *DeltaBackupConfig, delta 
 	backup.CreatedTime = util.Now()
 	backup.Size = int64(len(backup.Blocks)) * DEFAULT_BLOCK_SIZE
 	backup.Labels = config.Labels
+	backup.ObjectStoreBackup = volume.ObjectStoreBackup
 	backup.IsIncremental = lastBackup != nil
 
 	if err := saveBackup(bsDriver, backup); err != nil {
@@ -554,6 +555,7 @@ func performBackup(bsDriver BackupStoreDriver, config *DeltaBackupConfig, delta 
 	volume.CompressionMethod = config.Volume.CompressionMethod
 	volume.StorageClassName = config.Volume.StorageClassName
 	volume.BackendStoreDriver = config.Volume.BackendStoreDriver
+	volume.ObjectStoreBackup = config.Volume.ObjectStoreBackup
 
 	if err := saveVolume(bsDriver, volume); err != nil {
 		return progress.progress, "", err

--- a/inspect.go
+++ b/inspect.go
@@ -77,6 +77,7 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 		BackingImageChecksum: volume.BackingImageChecksum,
 		StorageClassname:     volume.StorageClassName,
 		BackendStoreDriver:   volume.BackendStoreDriver,
+		ObjectStoreBackup:    volume.ObjectStoreBackup,
 	}
 }
 
@@ -91,6 +92,7 @@ func fillBackupInfo(backup *Backup, destURL string) *BackupInfo {
 		Labels:            backup.Labels,
 		IsIncremental:     backup.IsIncremental,
 		CompressionMethod: backup.CompressionMethod,
+		ObjectStoreBackup: backup.ObjectStoreBackup,
 	}
 }
 

--- a/list.go
+++ b/list.go
@@ -29,6 +29,7 @@ type VolumeInfo struct {
 	BackingImageChecksum string
 	StorageClassname     string
 	BackendStoreDriver   string
+	ObjectStoreBackup    string `json:",omitempty"`
 }
 
 type BackupInfo struct {
@@ -46,6 +47,7 @@ type BackupInfo struct {
 	VolumeSize             int64  `json:",string,omitempty"`
 	VolumeCreated          string `json:",omitempty"`
 	VolumeBackingImageName string `json:",omitempty"`
+	ObjectStoreBackup      string `json:",omitempty"`
 
 	Messages map[types.MessageType]string
 }


### PR DESCRIPTION
Implementation of backup functionality for the object store.
The object store consists of a normal longhorn volume and an object storage gateway (s3gw) instance. In case of a backup, the details of the object storage gateway deployment must be backed up as well, to be able to restore the entire object store. Therefore an object store backup carries additional metadata in the form of the deployment details of the object storage gateway.

Related: https://github.com/longhorn/longhorn/pull/6640
Related: https://github.com/longhorn/longhorn-manager/pull/2136
Related: https://github.com/longhorn/longhorn-ui/pull/649
Related: https://github.com/longhorn/longhorn-engine/pull/934
Related: https://github.com/longhorn/longhorn-instance-manager/pull/285

LEP: https://github.com/longhorn/longhorn/pull/5832