### PR TITLE
doc(lock): add comments for backup backing image lock

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -51,5 +51,11 @@ type JobResult struct {
 }
 
 const (
+	// This is used for all the BackingImages since they all share the same block pool.
+	// For lock mechanism, please refer to: https://github.com/longhorn/longhorn/blob/master/enhancements/20200701-backupstore-file-locks.md#proposal
+	// Currently the lock file is stored in each BackupVolume folder.
+	// For BackingImage Lock it is also stored there with the folder name "BACKINGIMAGE" defined here.
+	// To prevent Longhorn from accidently considering it as another normal BackupVolume,
+	// we use upppercase here so it will be filtered out when listing.
 	BackupBackingImageLockName = "BACKINGIMAGE"
 )


### PR DESCRIPTION
ref: longhorn/longhorn 4165

#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/4165

#### What this PR does / why we need it:
Add comments to backup backing image lock to explain the consideration.

#### Special notes for your reviewer:

#### Additional documentation or context
