### PR TITLE
Make restore goroutine stoppable by an external context

### DIFF
--- a/deltablock.go
+++ b/deltablock.go
@@ -752,7 +752,7 @@ func restoreBlockToFile(bsDriver BackupStoreDriver, volumeName string, volDev *o
 	return err
 }
 
-func RestoreDeltaBlockBackupIncrementally(config *DeltaRestoreConfig) error {
+func RestoreDeltaBlockBackupIncrementally(ctx context.Context, config *DeltaRestoreConfig) error {
 	if config == nil {
 		return fmt.Errorf("invalid empty config for restore")
 	}
@@ -864,7 +864,7 @@ func RestoreDeltaBlockBackupIncrementally(config *DeltaRestoreConfig) error {
 			}
 		}
 
-		if err := performIncrementalRestore(bsDriver, config, srcVolumeName, volDevName, lastBackup, backup); err != nil {
+		if err := performIncrementalRestore(ctx, bsDriver, config, srcVolumeName, volDevName, lastBackup, backup); err != nil {
 			deltaOps.UpdateRestoreStatus(volDevName, 0, err)
 			return
 		}
@@ -1018,7 +1018,7 @@ func restoreBlocks(ctx context.Context, bsDriver BackupStoreDriver, deltaOps Del
 	return errChan
 }
 
-func performIncrementalRestore(bsDriver BackupStoreDriver, config *DeltaRestoreConfig,
+func performIncrementalRestore(ctx context.Context, bsDriver BackupStoreDriver, config *DeltaRestoreConfig,
 	srcVolumeName, volDevName string, lastBackup *Backup, backup *Backup) error {
 	var err error
 	concurrentLimit := config.ConcurrentLimit
@@ -1026,9 +1026,6 @@ func performIncrementalRestore(bsDriver BackupStoreDriver, config *DeltaRestoreC
 	progress := &progress{
 		totalBlockCounts: int64(len(backup.Blocks) + len(lastBackup.Blocks)),
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	blockChan, errChan := populateBlocksForIncrementalRestore(bsDriver, lastBackup, backup)
 

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
@@ -391,7 +392,8 @@ func (s *TestSuite) TestBackupBasic(c *C) {
 				Filename:        restore,
 				ConcurrentLimit: int32(concurrentLimit),
 			}
-			err := backupstore.RestoreDeltaBlockBackup(rConfig)
+
+			err := backupstore.RestoreDeltaBlockBackup(context.Background(), rConfig)
 			c.Assert(err, IsNil)
 			s.waitForRestoreCompletion(c, &volume)
 
@@ -620,7 +622,7 @@ func (s *TestSuite) TestBackupRestoreExtra(c *C) {
 				ConcurrentLimit: int32(concurrentLimit),
 			}
 
-			err := backupstore.RestoreDeltaBlockBackup(rConfig)
+			err := backupstore.RestoreDeltaBlockBackup(context.Background(), rConfig)
 			c.Assert(err, IsNil)
 			s.waitForRestoreCompletion(c, &volume)
 

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -637,7 +637,7 @@ func (s *TestSuite) TestBackupRestoreExtra(c *C) {
 				ConcurrentLimit: int32(concurrentLimit),
 			}
 
-			err = backupstore.RestoreDeltaBlockBackupIncrementally(rConfig)
+			err = backupstore.RestoreDeltaBlockBackupIncrementally(context.Background(), rConfig)
 			if i == 0 {
 				c.Assert(err, NotNil)
 				c.Assert(err, ErrorMatches, "invalid parameter lastBackupName "+lastBackupName)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue https://github.com/longhorn/longhorn/issues/7581

#### What this PR does / why we need it:

Make restore goroutine stoppable by an external context

#### Special notes for your reviewer:

#### Additional documentation or context
