### PR TITLE
fix: skip remove backup volume if the dir is already gone

### DIFF
--- a/deltablock.go
+++ b/deltablock.go
@@ -1051,6 +1051,12 @@ func DeleteBackupVolume(volumeName string, destURL string) error {
 	if err != nil {
 		return err
 	}
+
+	// no need to lock and remove volume if it does not exist
+	if !volumeExists(bsDriver, volumeName) {
+		return nil
+	}
+
 	lock, err := New(bsDriver, volumeName, DELETION_LOCK)
 	if err != nil {
 		return err


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7744

There is a chance that `BackupVolumeDelete()` will be executed twice even the finalizer of the BackupVolume is already gone.
Every time `DeleteBackupVolume()` is executed, it will create a lock file.
It is possible that during the second execution, the nfs is unmount because the BackupTarget is unset after BackupVolumes are all deleted in some automated operations (e.g. longhorn e2e test)
So the lock remains on nfs and it pollutes the env.