### PR TITLE
Revert "fix: skip remove backup volume if the dir is already gone"

### DIFF
--- a/deltablock.go
+++ b/deltablock.go
@@ -1051,12 +1051,6 @@ func DeleteBackupVolume(volumeName string, destURL string) error {
 	if err != nil {
 		return err
 	}
-
-	// no need to lock and remove volume if it does not exist
-	if !volumeExists(bsDriver, volumeName) {
-		return nil
-	}
-
 	lock, err := New(bsDriver, volumeName, DELETION_LOCK)
 	if err != nil {
 		return err


### PR DESCRIPTION
This reverts commit 1d5129cd1074445964733aa74257d0acd4fc7d9e. The PR results in the failed test cases:
  test_basic.py::test_backup_metadata_deletion[s3] FAILED
  test_basic.py::test_backup_metadata_deletion[nfs] FAILED

Longhorn/longhorn#7744

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
