### PR TITLE
fix: skip deletion if folder does not exist

### DIFF
--- a/deltablock.go
+++ b/deltablock.go
@@ -1051,6 +1051,17 @@ func DeleteBackupVolume(volumeName string, destURL string) error {
 	if err != nil {
 		return err
 	}
+
+	backupVolumeFolderExists, err := volumeFolderExists(bsDriver, volumeName)
+	if err != nil {
+		return err
+	}
+
+	// No need to lock and remove volume if it does not exist.
+	if !backupVolumeFolderExists {
+		return nil
+	}
+
 	lock, err := New(bsDriver, volumeName, DELETION_LOCK)
 	if err != nil {
 		return err


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7744

Since s3 doesn't support checking if folder exists.
We can use existing `getVolumeNames` which "returns all volume names based on the folders on the backupstore"
to see if the folder exists or not.