### PR TITLE
fix: backup progress should not add block failed to upload to successful count

### DIFF
--- a/backupbackingimage/backupbackingimage.go
+++ b/backupbackingimage/backupbackingimage.go
@@ -264,7 +264,8 @@ func backupMapping(bsDriver backupstore.BackupStoreDriver,
 		return err
 	}
 
-	return bsDriver.Write(blkFile, rs)
+	err = bsDriver.Write(blkFile, rs)
+	return err
 }
 
 // isBlockBeingProcessed check if the block is being processed by other goroutine and prevent redundant work

--- a/deltablock.go
+++ b/deltablock.go
@@ -425,7 +425,8 @@ func backupBlock(bsDriver BackupStoreDriver, config *DeltaBackupConfig,
 		return errors.Wrapf(err, "failed to get transfer data size during saving blocks")
 	}
 
-	if err := bsDriver.Write(blkFile, rs); err != nil {
+	err = bsDriver.Write(blkFile, rs)
+	if err != nil {
 		return errors.Wrapf(err, "failed to write data during saving blocks")
 	}
 


### PR DESCRIPTION

Longhorn/longhorn#9791

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling during the block writing and backup mapping processes, allowing for better tracking and logging of issues.
	- Improved clarity of error messages related to backing image size and completion status.
- **Chores**
	- Refined the existing backup process without introducing new functionality or altering existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->