### PR TITLE
fix: don't copy mutex

### DIFF
--- a/backupstore.go
+++ b/backupstore.go
@@ -56,6 +56,11 @@ type Backup struct {
 	SingleFile BackupFile     `json:",omitempty"`
 }
 
+type LastBackupInfo struct {
+	Name              string
+	SnapshotCreatedAt string
+}
+
 var (
 	backupstoreBase = "backupstore"
 )


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/6965

#### What this PR does / why we need it:

Only copy the fields we need.

#### Special notes for your reviewer:

#### Additional documentation or context

Passes unit tests and backup-related regression tests: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8232


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced backup management by adding detailed metadata (backup name and snapshot timestamp) for improved tracking of recent backups.
  
- **Refactor**
  - Refined the backup update process by isolating the data transfer logic, ensuring more consistent and reliable handling of backup information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->