### PR TITLE
fix: update the progress if the backup already exists and we dont perform backup

### DIFF
--- a/backupbackingimage/backupbackingimage.go
+++ b/backupbackingimage/backupbackingimage.go
@@ -116,6 +116,7 @@ func CreateBackingImageBackup(config *BackupConfig, backupBackingImage *BackupBa
 
 	if exists {
 		log.Info("Backup BackingImage already exists, no need to perform backup")
+		backupOperation.UpdateBackupProgress(string(common.ProgressStateInProgress), 100, EncodeBackupBackingImageURL(config.Name, config.DestURL), "")
 		return nil
 	}
 


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/10740

There is a chance that the backup is triggered again even the content already exists in the backupstore
we should update the status to 100% so the CR status can have correct info