### PR TITLE
s3: expose retry/backoff constants via environment variables

### DIFF
--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,10 +41,52 @@ const (
 	// AWSRetryMaximumBackoff specifies the maximum duration between retried attempts.
 	AWSRetryMaximumBackoff = 300 * time.Second
 
+	// EnvAWSRetryMaxAttempts overrides AWSRetryMaxAttempts when set to a positive integer.
+	EnvAWSRetryMaxAttempts = "AWS_RETRY_MAX_ATTEMPTS"
+	// EnvAWSRetryMaximumAttempts overrides AWSRetryMaximumAttempts when set to a positive integer.
+	EnvAWSRetryMaximumAttempts = "AWS_RETRY_MAXIMUM_ATTEMPTS"
+	// EnvAWSRetryMaximumBackoff overrides AWSRetryMaximumBackoff when set to a Go duration string (e.g. "60s", "5m").
+	EnvAWSRetryMaximumBackoff = "AWS_RETRY_MAXIMUM_BACKOFF"
+
 	// InvalidRequestErrorMsg is the error message returned by S3 Compatible services when the authorization mechanism is not supported,
 	// which can be caused by using AWS Signature Version 2 for signing requests to AWS S3 regions that require AWS Signature Version 4.
 	InvalidRequestErrorMsg = "The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256."
 )
+
+// retryMaxAttempts returns the configured retry max attempts, falling back to
+// AWSRetryMaxAttempts when the env var is unset, empty, or malformed.
+func retryMaxAttempts() int {
+	if v := os.Getenv(EnvAWSRetryMaxAttempts); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return AWSRetryMaxAttempts
+}
+
+// retryMaximumAttempts returns the configured retry maximum attempts, falling
+// back to AWSRetryMaximumAttempts when the env var is unset, empty, or
+// malformed.
+func retryMaximumAttempts() int {
+	if v := os.Getenv(EnvAWSRetryMaximumAttempts); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return AWSRetryMaximumAttempts
+}
+
+// retryMaximumBackoff returns the configured retry maximum backoff, falling
+// back to AWSRetryMaximumBackoff when the env var is unset, empty, or
+// malformed.
+func retryMaximumBackoff() time.Duration {
+	if v := os.Getenv(EnvAWSRetryMaximumBackoff); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return AWSRetryMaximumBackoff
+}
 
 func newService(u *url.URL) (*service, error) {
 	s := service{}
@@ -75,7 +118,7 @@ func (s *service) newInstance(ctx context.Context, retryBackoff bool) (*s3.Clien
 	// Load AWS configuration
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(s.Region),
-		config.WithRetryMaxAttempts(AWSRetryMaxAttempts),
+		config.WithRetryMaxAttempts(retryMaxAttempts()),
 		config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
 		config.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
 	)
@@ -107,8 +150,8 @@ func (s *service) newInstance(ctx context.Context, retryBackoff bool) (*s3.Clien
 		o.UsePathStyle = usePathStyle
 		if retryBackoff {
 			o.Retryer = retry.NewStandard(func(so *retry.StandardOptions) {
-				so.MaxAttempts = AWSRetryMaximumAttempts
-				so.MaxBackoff = AWSRetryMaximumBackoff
+				so.MaxAttempts = retryMaximumAttempts()
+				so.MaxBackoff = retryMaximumBackoff()
 			})
 		}
 		// Google Cloud Storage alters the `Accept-Encoding` header (GCS might changes the header on its way to GCS by appending gzip(gfe) as accepted encoding),

--- a/s3/s3_service_retry_test.go
+++ b/s3/s3_service_retry_test.go
@@ -1,0 +1,71 @@
+package s3
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRetryMaxAttempts_EnvOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset", "", AWSRetryMaxAttempts},
+		{"valid", "7", 7},
+		{"zero falls back", "0", AWSRetryMaxAttempts},
+		{"negative falls back", "-1", AWSRetryMaxAttempts},
+		{"garbage falls back", "abc", AWSRetryMaxAttempts},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvAWSRetryMaxAttempts, tc.env)
+			if got := retryMaxAttempts(); got != tc.want {
+				t.Fatalf("retryMaxAttempts() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryMaximumAttempts_EnvOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset", "", AWSRetryMaximumAttempts},
+		{"valid", "20", 20},
+		{"zero falls back", "0", AWSRetryMaximumAttempts},
+		{"garbage falls back", "x", AWSRetryMaximumAttempts},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvAWSRetryMaximumAttempts, tc.env)
+			if got := retryMaximumAttempts(); got != tc.want {
+				t.Fatalf("retryMaximumAttempts() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryMaximumBackoff_EnvOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset", "", AWSRetryMaximumBackoff},
+		{"valid seconds", "60s", 60 * time.Second},
+		{"valid minutes", "5m", 5 * time.Minute},
+		{"zero falls back", "0s", AWSRetryMaximumBackoff},
+		{"garbage falls back", "nope", AWSRetryMaximumBackoff},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvAWSRetryMaximumBackoff, tc.env)
+			if got := retryMaximumBackoff(); got != tc.want {
+				t.Fatalf("retryMaximumBackoff() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#12155

#### What this PR does / why we need it:

The S3 backupstore service hardcodes three retry-related constants — [`AWSRetryMaxAttempts` (5)](https://github.com/longhorn/backupstore/blob/master/s3/s3_service.go#L37), [`AWSRetryMaximumAttempts` (10)](https://github.com/longhorn/backupstore/blob/master/s3/s3_service.go#L39), and [`AWSRetryMaximumBackoff` (300s)](https://github.com/longhorn/backupstore/blob/master/s3/s3_service.go#L41). Operators running against S3-compatible endpoints with different latency or reliability characteristics have no way to tune them without recompiling.

This PR adds three optional environment-variable overrides, following the existing `AWS_ENDPOINTS` / `VIRTUAL_HOSTED_STYLE` env-var pattern already used by this file:

| Env var | Type | Overrides |
|---|---|---|
| `AWS_RETRY_MAX_ATTEMPTS` | positive integer | `AWSRetryMaxAttempts` |
| `AWS_RETRY_MAXIMUM_ATTEMPTS` | positive integer | `AWSRetryMaximumAttempts` |
| `AWS_RETRY_MAXIMUM_BACKOFF` | Go duration (`60s`, `5m`) | `AWSRetryMaximumBackoff` |

Empty, missing, or malformed values silently fall back to the existing defaults, so no behaviour change for users that don't set them. Unit tests for each helper cover unset / valid / zero / negative / malformed cases.

#### Special notes for your reviewer:

- I kept the existing exported constants unchanged so other callers (and the longhorn/longhorn integration) keep compiling.
- The new helpers are lowercase / package-local since they only apply to this file's retry plumbing.
- Once this lands I'm happy to open a companion PR against `longhorn/longhorn` exposing these as global settings / backup-target URL parameters per the issue description; figured it was cleaner to land the library-side primitive first.

#### Additional documentation or context

- longhorn/longhorn#12155