### PR TITLE
fix(s3): disable default checksum calculation for multipart uploads

### DIFF
--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -203,7 +203,19 @@ func (s *service) PutObject(ctx context.Context, key string, reader io.ReadSeeke
 	defer s.Close()
 
 	// Use the AWS S3 uploader which handles signing correctly
-	uploader := manager.NewUploader(svc)
+	// manager.NewUploader defaults RequestChecksumCalculation to
+	// aws.RequestChecksumCalculationWhenSupported, independent of the
+	// RequestChecksumCalculation set on the underlying s3.Client. That default
+	// makes the uploader always add a CRC32 trailing checksum for multipart
+	// uploads, which forces the request body to use aws-chunked content
+	// encoding. Some S3-compatible providers (e.g. OCI) don't support
+	// aws-chunked and reject the request with "NotImplemented: AWS chunked
+	// encoding is not supported". Align the uploader with the client's
+	// WhenRequired setting so checksums (and aws-chunked encoding) are only
+	// used when required.
+	uploader := manager.NewUploader(svc, func(u *manager.Uploader) {
+		u.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+	})
 
 	// Ensure reader is at the beginning
 	if _, err := reader.Seek(0, io.SeekStart); err != nil {


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13477

#### What this PR does / why we need it:

manager.NewUploader() defaults its own RequestChecksumCalculation field to aws.RequestChecksumCalculationWhenSupported, independent of the WhenRequired setting already configured on the underlying s3.Client. This caused multipart uploads (used for larger backup blocks) to always attach a CRC32 trailing checksum, which forces the request body to use aws-chunked content encoding.

Some S3-compatible providers, such as OCI, do not support aws-chunked encoding and reject the request with:
"NotImplemented: AWS chunked encoding is not supported."

Explicitly set the uploader's RequestChecksumCalculation to WhenRequired to match the client setting, so checksums are only calculated when required.

#### Special notes for your reviewer:

#### Additional documentation or context
