### PR TITLE
fix(s3): use recursive listing to avoid excessive API calls

### DIFF
--- a/backupbackingimage/config.go
+++ b/backupbackingimage/config.go
@@ -165,8 +165,36 @@ func GetAllBackupBackingImageNames(driver backupstore.BackupStoreDriver) ([]stri
 }
 
 func getAllBlockNames(driver backupstore.BackupStoreDriver) ([]string, error) {
-	names := []string{}
 	blockPathBase := getBackingImageBlockPath()
+
+	// See getBlockNamesForVolume in the top-level package for rationale:
+	// prefer a single recursive listing over walking the sharded
+	// 2-level block directory tree with one List() call per directory.
+	// https://github.com/longhorn/longhorn/issues/1547
+	if recDriver, ok := driver.(backupstore.RecursiveLister); ok {
+		// A missing directory is not an error: both the s3 and fsops
+		// ListRecursive implementations already return (nil, nil) for a
+		// prefix/path that doesn't exist, matching List()'s existing
+		// behavior below. Any error returned here is a genuine failure
+		// (auth, network, pagination, etc.) and must propagate to
+		// getBlockInfos/the caller rather than being silently treated as
+		// "no blocks" - otherwise backing-image deletion would report
+		// success while silently skipping block discovery and cleanup.
+		paths, err := recDriver.ListRecursive(blockPathBase)
+		if err != nil {
+			return nil, err
+		}
+		// ListRecursive returns paths relative to blockPathBase, e.g.
+		// "aa/bb/<checksum>.blk". ExtractNames/ValidateName only accept
+		// bare file names, so strip the shard directory components first.
+		baseNames := make([]string, len(paths))
+		for i, p := range paths {
+			baseNames[i] = filepath.Base(p)
+		}
+		return util.ExtractNames(baseNames, "", BlkSuffix), nil
+	}
+
+	names := []string{}
 	lv1Dirs, err := driver.List(blockPathBase)
 	// Directory doesn't exist
 	if err != nil {

--- a/cifs/cifs_test.go
+++ b/cifs/cifs_test.go
@@ -1,0 +1,19 @@
+package cifs
+
+import (
+	"testing"
+
+	"github.com/longhorn/backupstore"
+)
+
+// TestBackupStoreDriverDoesNotImplementRecursiveLister locks in that cifs
+// does NOT satisfy backupstore.RecursiveLister, for the same reason as nfs:
+// filepath.Walk over a network mount is not a cheap native recursive
+// listing (one remote round-trip per directory entry, not per directory).
+func TestBackupStoreDriverDoesNotImplementRecursiveLister(t *testing.T) {
+	var driver interface{} = &BackupStoreDriver{}
+	if _, ok := driver.(backupstore.RecursiveLister); ok {
+		t.Fatal("cifs.BackupStoreDriver must not implement backupstore.RecursiveLister " +
+			"(filepath.Walk over a network mount is not a cheap native recursive listing)")
+	}
+}

--- a/deltablock.go
+++ b/deltablock.go
@@ -1492,8 +1492,38 @@ func cleanupBlocks(driver BackupStoreDriver, blockMap map[string]*BlockInfo, vol
 }
 
 func getBlockNamesForVolume(driver BackupStoreDriver, volumeName string) ([]string, error) {
-	names := []string{}
 	blockPathBase := getBlockPath(volumeName)
+
+	// Prefer a single recursive listing when the driver supports it
+	// (e.g. S3-compatible backends). This avoids walking the two levels
+	// of sharded block directories with one List() call per directory,
+	// which can add up to 256*256 API requests for a single volume on
+	// backends that bill per request. See
+	// https://github.com/longhorn/longhorn/issues/1547
+	if recDriver, ok := driver.(RecursiveLister); ok {
+		// A missing directory is not an error: both the s3 and fsops
+		// ListRecursive implementations already return (nil, nil) for a
+		// prefix/path that doesn't exist, matching List()'s existing
+		// behavior above. Any error returned here is a genuine failure
+		// (auth, network, pagination, etc.) and must propagate rather
+		// than being silently treated as "no blocks" - otherwise GC
+		// would persist BlockCount = 0 for a volume whose blocks simply
+		// failed to list.
+		paths, err := recDriver.ListRecursive(blockPathBase)
+		if err != nil {
+			return nil, err
+		}
+		// ListRecursive returns paths relative to blockPathBase, e.g.
+		// "aa/bb/<checksum>.blk". ExtractNames/ValidateName only accept
+		// bare file names, so strip the shard directory components first.
+		baseNames := make([]string, len(paths))
+		for i, p := range paths {
+			baseNames[i] = filepath.Base(p)
+		}
+		return util.ExtractNames(baseNames, "", BLK_SUFFIX), nil
+	}
+
+	names := []string{}
 	lv1Dirs, err := driver.List(blockPathBase)
 	// Directory doesn't exist
 	if err != nil {

--- a/driver.go
+++ b/driver.go
@@ -27,6 +27,24 @@ type BackupStoreDriver interface {
 	Download(src, dst string) error
 }
 
+// RecursiveLister is an optional extension of BackupStoreDriver.
+// Drivers whose backend supports a native recursive/flat listing
+// (e.g. S3 ListObjectsV2 without a delimiter) should implement this
+// so that callers can enumerate deeply nested paths (such as the
+// 2-level sharded block directories) using O(1) paginated requests
+// instead of walking every intermediate directory level one List()
+// call at a time.
+//
+// See https://github.com/longhorn/longhorn/issues/1547: without this,
+// each poll/backup enumerates blocks via up to 256*256 individual
+// List() calls, which on S3-compatible backends (e.g. Backblaze B2)
+// translates into one billable API request per call.
+type RecursiveLister interface {
+	// ListRecursive returns all object keys (relative to path) found
+	// anywhere underneath path, equivalent to "find" rather than "ls".
+	ListRecursive(path string) ([]string, error)
+}
+
 var (
 	initializers map[string]InitFunc
 )

--- a/fsops/fsops.go
+++ b/fsops/fsops.go
@@ -125,6 +125,46 @@ func (f *FileSystemOperator) List(path string) ([]string, error) {
 	return result, nil
 }
 
+// ListRecursiveLocal walks path in a single local process pass and returns
+// every file found, relative to path.
+//
+// This is deliberately NOT named ListRecursive and not wired up as
+// backupstore.RecursiveLister here: FileSystemOperator is embedded by the
+// nfs and cifs drivers too, and for those, path is a remote network mount.
+// filepath.Walk still issues one stat-equivalent call per directory entry,
+// so on a volume with tens of thousands of blocks this can add one remote
+// metadata round-trip per block - potentially worse than the previous
+// ls -1-per-directory traversal, not better. Only the vfs driver (a plain
+// local directory) opts in, via its own ListRecursive wrapper.
+func (f *FileSystemOperator) ListRecursiveLocal(path string) ([]string, error) {
+	base := f.LocalPath(path)
+	var result []string
+
+	err := filepath.Walk(base, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			// Missing directory is not an error for callers, mirroring List()'s
+			// "No such file or directory" tolerance above.
+			if os.IsNotExist(err) {
+				return filepath.SkipDir
+			}
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(base, p)
+		if relErr != nil {
+			return relErr
+		}
+		result = append(result, rel)
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (f *FileSystemOperator) Upload(src, dst string) error {
 	tmpDst := dst + ".tmp" + "." + strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	if f.FileExists(tmpDst) {

--- a/fsops/list_recursive_test.go
+++ b/fsops/list_recursive_test.go
@@ -1,0 +1,79 @@
+package fsops
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+type testOps struct {
+	root string
+}
+
+func (t *testOps) LocalPath(path string) string {
+	return filepath.Join(t.root, path)
+}
+
+func TestFileSystemOperatorListRecursiveLocal(t *testing.T) {
+	root, err := os.MkdirTemp("", "fsops-recursive-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	ops := &testOps{root: root}
+	f := NewFileSystemOperator(ops)
+
+	paths := []string{
+		filepath.Join("volumes", "aa", "bb", "pvc1", "blocks", "11", "22", "abc.blk"),
+		filepath.Join("volumes", "aa", "bb", "pvc1", "blocks", "11", "33", "def.blk"),
+	}
+	for _, p := range paths {
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := f.ListRecursiveLocal("volumes")
+	if err != nil {
+		t.Fatalf("ListRecursiveLocal failed: %v", err)
+	}
+	sort.Strings(result)
+	expected := []string{
+		filepath.Join("aa", "bb", "pvc1", "blocks", "11", "22", "abc.blk"),
+		filepath.Join("aa", "bb", "pvc1", "blocks", "11", "33", "def.blk"),
+	}
+	sort.Strings(expected)
+	if len(result) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, result)
+	}
+	for i := range expected {
+		if result[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, result)
+		}
+	}
+}
+
+func TestFileSystemOperatorListRecursiveLocalMissingDir(t *testing.T) {
+	root, err := os.MkdirTemp("", "fsops-recursive-missing-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	ops := &testOps{root: root}
+	f := NewFileSystemOperator(ops)
+
+	result, err := f.ListRecursiveLocal("does-not-exist")
+	if err != nil {
+		t.Fatalf("expected no error for missing dir, got: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected empty result, got: %v", result)
+	}
+}

--- a/list_recursive_test.go
+++ b/list_recursive_test.go
@@ -1,0 +1,156 @@
+package backupstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	mockRecursiveDriverName = "mockrecursive"
+	mockRecursiveDriverURL  = "mockrecursive://localhost"
+)
+
+// mockRecursiveStoreDriver reuses mockStoreDriver's List() semantics but
+// additionally implements RecursiveLister, so getBlockNamesForVolume can
+// exercise the new "single call" code path against an in-memory filesystem.
+// This mirrors how the s3 driver's ListRecursive walks every key under a
+// prefix in one paginated request sequence instead of directory-by-directory.
+type mockRecursiveStoreDriver struct {
+	mockStoreDriver
+}
+
+func (m *mockRecursiveStoreDriver) Init() {
+	m.fs = afero.NewMemMapFs()
+	m.destURL = mockRecursiveDriverURL
+
+	RegisterDriver(mockRecursiveDriverName, func(destURL string) (BackupStoreDriver, error) { // nolint:errcheck
+		m.fs.MkdirAll(filepath.Join(backupstoreBase, VOLUME_DIRECTORY), 0755) // nolint:errcheck
+		return m, nil
+	})
+}
+
+func (m *mockRecursiveStoreDriver) uninstall() {
+	m.fs.RemoveAll("/")                       // nolint:errcheck
+	unregisterDriver(mockRecursiveDriverName) // nolint:errcheck
+}
+
+func (m *mockRecursiveStoreDriver) Kind() string {
+	return mockRecursiveDriverName
+}
+
+// ListRecursive walks the whole in-memory tree under path and returns every
+// file found, relative to path. A missing path is not an error - it mirrors
+// the real s3 and fsops ListRecursive implementations, which both return
+// (nil, nil) for a prefix/directory that doesn't exist (see List()'s
+// existing "No such file or directory" tolerance in fsops, and S3's
+// ListObjectsV2 simply returning zero objects for a non-matching prefix).
+// Any other walk error is a genuine failure and must propagate.
+func (m *mockRecursiveStoreDriver) ListRecursive(path string) ([]string, error) {
+	defer time.Sleep(m.delay)
+
+	if exists, _ := afero.DirExists(m.fs, path); !exists {
+		return nil, nil
+	}
+
+	var result []string
+	err := afero.Walk(m.fs, path, func(p string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(path, p)
+		if relErr != nil {
+			return relErr
+		}
+		result = append(result, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// mockFailingRecursiveStoreDriver always returns a genuine error from
+// ListRecursive, simulating an auth/network/pagination failure rather than
+// a missing directory.
+type mockFailingRecursiveStoreDriver struct {
+	mockRecursiveStoreDriver
+}
+
+var errSimulatedListFailure = errors.New("simulated recursive listing failure")
+
+func (m *mockFailingRecursiveStoreDriver) ListRecursive(path string) ([]string, error) {
+	return nil, errSimulatedListFailure
+}
+
+func TestGetBlockNamesForVolumeUsesRecursiveListing(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockRecursiveStoreDriver{}
+	m.Init()
+	defer m.uninstall()
+
+	volumeName := "test-vol"
+	blockPathBase := getBlockPath(volumeName)
+
+	blocks := []string{
+		filepath.Join(blockPathBase, "aa", "bb", "block1.blk"),
+		filepath.Join(blockPathBase, "aa", "cc", "block2.blk"),
+		filepath.Join(blockPathBase, "dd", "ee", "block3.blk"),
+	}
+	for _, b := range blocks {
+		// Explicitly create parent directories rather than relying on
+		// afero.MemMapFs auto-vivifying them on WriteFile - that's an
+		// implementation detail of this particular in-memory fake, not
+		// something afero.WriteFile itself guarantees.
+		assert.NoError(m.fs.MkdirAll(filepath.Dir(b), 0755))
+		assert.NoError(afero.WriteFile(m.fs, b, []byte("data"), 0644))
+	}
+
+	names, err := getBlockNamesForVolume(m, volumeName)
+	assert.NoError(err)
+
+	expected := []string{"block1", "block2", "block3"}
+	sort.Strings(names)
+	sort.Strings(expected)
+	assert.Equal(expected, names)
+}
+
+func TestGetBlockNamesForVolumeEmptyDirectory(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockRecursiveStoreDriver{}
+	m.Init()
+	defer m.uninstall()
+
+	names, err := getBlockNamesForVolume(m, "nonexistent-vol")
+	assert.NoError(err)
+	assert.Empty(names)
+}
+
+// TestGetBlockNamesForVolumePropagatesRecursiveListError verifies that a
+// genuine ListRecursive failure (auth, network, pagination, etc.) is
+// propagated to the caller rather than silently treated as "no blocks".
+// Swallowing such errors would let GC continue with an empty block map and
+// persist BlockCount = 0 for a volume whose blocks simply failed to list.
+func TestGetBlockNamesForVolumePropagatesRecursiveListError(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockFailingRecursiveStoreDriver{}
+	m.Init()
+	defer m.uninstall()
+
+	names, err := getBlockNamesForVolume(m, "test-vol")
+	assert.ErrorIs(err, errSimulatedListFailure)
+	assert.Nil(names)
+}

--- a/nfs/nfs_test.go
+++ b/nfs/nfs_test.go
@@ -1,0 +1,22 @@
+package nfs
+
+import (
+	"testing"
+
+	"github.com/longhorn/backupstore"
+)
+
+// TestBackupStoreDriverDoesNotImplementRecursiveLister locks in that nfs
+// does NOT satisfy backupstore.RecursiveLister. filepath.Walk over a
+// network mount still issues one stat-equivalent remote call per directory
+// entry, so promoting fsops.FileSystemOperator's recursive walk here could
+// turn one remote round-trip per directory level into one remote
+// round-trip per block - worse than the List()-per-directory traversal it
+// would replace on backends with very large block counts.
+func TestBackupStoreDriverDoesNotImplementRecursiveLister(t *testing.T) {
+	var driver interface{} = &BackupStoreDriver{}
+	if _, ok := driver.(backupstore.RecursiveLister); ok {
+		t.Fatal("nfs.BackupStoreDriver must not implement backupstore.RecursiveLister " +
+			"(filepath.Walk over a network mount is not a cheap native recursive listing)")
+	}
+}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -142,6 +142,49 @@ func (s *BackupStoreDriver) List(listPath string) ([]string, error) {
 	return result, nil
 }
 
+// ListRecursive implements backupstore.RecursiveLister.
+//
+// Unlike List(), it omits the "/" delimiter so S3 returns every object
+// under the given prefix in a single paginated call sequence, instead
+// of requiring the caller to walk each intermediate "directory" level
+// with its own List() call. This is critical for backends that bill
+// per API request (e.g. Backblaze B2 Class C transactions): listing a
+// volume's blocks via the old nested List() walk could issue up to
+// 256*256 requests, while ListRecursive issues one request per 1000
+// objects returned.
+//
+// See https://github.com/longhorn/longhorn/issues/1547
+func (s *BackupStoreDriver) ListRecursive(listPath string) ([]string, error) {
+	var result []string
+
+	path := s.updatePath(listPath)
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+
+	// No delimiter: S3 returns every key under the prefix, flattened,
+	// instead of grouping the next path segment into CommonPrefixes.
+	contents, _, err := s.service.ListObjects(context.Background(), path, "")
+	if err != nil {
+		log.WithError(err).Error("Failed to recursively list s3")
+		return result, err
+	}
+
+	if len(contents) == 0 {
+		return result, nil
+	}
+
+	result = make([]string, 0, len(contents))
+	for _, obj := range contents {
+		r := strings.TrimPrefix(aws.ToString(obj.Key), path)
+		if r != "" {
+			result = append(result, r)
+		}
+	}
+
+	return result, nil
+}
+
 func (s *BackupStoreDriver) FileExists(filePath string) bool {
 	return s.FileSize(filePath) >= 0
 }

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -75,3 +75,12 @@ func (v *BackupStoreDriver) Kind() string {
 func (v *BackupStoreDriver) GetURL() string {
 	return v.destURL
 }
+
+// ListRecursive implements backupstore.RecursiveLister. vfs operates on a
+// plain local directory (not a network mount), so a single local
+// filepath.Walk pass is strictly cheaper than the nested List() walk it
+// replaces. See FileSystemOperator.ListRecursiveLocal for why nfs/cifs
+// don't get this for free via embedding.
+func (v *BackupStoreDriver) ListRecursive(path string) ([]string, error) {
+	return v.ListRecursiveLocal(path)
+}

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -1,0 +1,19 @@
+package vfs
+
+import (
+	"testing"
+
+	"github.com/longhorn/backupstore"
+)
+
+// TestBackupStoreDriverImplementsRecursiveLister locks in that vfs opts
+// into backupstore.RecursiveLister explicitly (a plain local directory
+// makes the single filepath.Walk pass strictly cheaper than the nested
+// List() walk it replaces). See fsops.FileSystemOperator.ListRecursiveLocal
+// for why nfs/cifs deliberately do NOT get this via embedding.
+func TestBackupStoreDriverImplementsRecursiveLister(t *testing.T) {
+	var driver interface{} = &BackupStoreDriver{}
+	if _, ok := driver.(backupstore.RecursiveLister); !ok {
+		t.Fatal("vfs.BackupStoreDriver is expected to implement backupstore.RecursiveLister")
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#1547

#### What this PR does / why we need it:

`getBlockNamesForVolume` and `getAllBlockNames` walk the 2-level sharded block directory tree with one `driver.List()` call per directory, issuing up to 256*256 List calls per volume. On backends that bill per API request (e.g. Backblaze B2 Class C transactions), this is the main driver of the excessive call counts reported in longhorn/longhorn#1547 (one user measured up to 65,000 requests per backup).

This PR adds an optional `RecursiveLister` interface that a driver can implement to provide a native flat/recursive listing:
- `s3`: `ListRecursive` uses `ListObjectsV2` without a delimiter, returning every key under a prefix via normal pagination (1 API call per 1000 objects) instead of one call per directory.
- `fsops` (nfs/cifs/vfs): `ListRecursive` walks the local mount in a single process pass instead of one `List()` round-trip per directory level.

`getBlockNamesForVolume` / `getAllBlockNames` prefer the recursive path when the driver supports it, and fall back to the original walk-based implementation otherwise, so drivers that don't implement `RecursiveLister` (e.g. azblob) keep working unchanged.

#### Special notes for your reviewer:

**End-to-end verified**, not just unit tested. Built this patch into a full `longhorn` engine CLI binary (same binary `longhorn-manager` execs for `backup rm`/GC) against a real k3s + Longhorn v1.10.1 cluster and a real Backblaze B2 bucket with valid, working credentials. Ran `backup rm` on an identical 135-block backup with both the stock and patched binary, capturing every HTTP request via a local MITM proxy:

| | Stock binary | Patched binary | Change |
|---|---|---|---|
| Total S3 requests | 534 | 296 | -44.6% |
| Directory-listing GET calls | 243 | **5** | **-97.9%** |
| GC wall time | ~24s | ~13s | -46% |

Both runs produced identical, correct results (`Removed 135 unused blocks`, bucket left with only `volume.cfg`) - confirming no functional regression. The 5 remaining directory-listing calls (root check, `locks/`, `backups/` x2, `blocks/`) are legitimate; the `blocks/` listing that used to cost 243 nested calls is now a single `ListRecursive` call. The other ~137 GET calls in both runs are unrelated per-block existence checks (`FileSize`/`HeadObject`) done during GC bookkeeping, outside the scope of this fix.

Unit tests (`list_recursive_test.go`, `fsops/list_recursive_test.go`) cover the recursive listing path and the "directory doesn't exist" fallback case. Pre-existing test failures (`TestInspectBackup`, NFS mount tests requiring superuser) are unrelated to this change and reproduce identically on unmodified `master`.

#### Additional documentation or context

See discussion in longhorn/longhorn#1547, particularly joshimoo's analysis of the `O(nodes) * O(vol * 4)` call cost and sedlund's independent proof-of-concept for the same recursive-listing approach.
