### PR TITLE
fix(s3): delete unused blocks with bounded concurrency

### DIFF
--- a/backupbackingimage/backupbackingimage.go
+++ b/backupbackingimage/backupbackingimage.go
@@ -634,18 +634,33 @@ func getBlockInfos(bsDriver backupstore.BackupStoreDriver) (map[string]*common.B
 func cleanupBlocks(log *logrus.Entry, driver backupstore.BackupStoreDriver, blockMap map[string]*common.BlockInfo) error {
 	var deletionFailures []string
 	deletedBlockCount := int64(0)
-	for _, blk := range blockMap {
-		if common.IsBlockSafeToDelete(blk) {
-			if err := driver.Remove(blk.Path); err != nil {
-				deletionFailures = append(deletionFailures, blk.Checksum)
-				continue
+
+	if remover, ok := driver.(backupstore.ExactFileRemover); ok {
+		if err := backupstore.RemoveExactFiles(remover, func(yield func(string) bool) {
+			for _, blk := range blockMap {
+				if common.IsBlockSafeToDelete(blk) {
+					deletedBlockCount++
+					if !yield(blk.Path) {
+						return
+					}
+				}
 			}
-			deletedBlockCount++
+		}); err != nil {
+			return errors.Wrap(err, "failed to delete backing image blocks")
+		}
+	} else {
+		for _, blk := range blockMap {
+			if common.IsBlockSafeToDelete(blk) {
+				if err := driver.Remove(blk.Path); err != nil {
+					deletionFailures = append(deletionFailures, blk.Checksum)
+					continue
+				}
+				deletedBlockCount++
+			}
 		}
 	}
 
 	log.Infof("Removed %v blocks", deletedBlockCount)
-
 	if len(deletionFailures) > 0 {
 		return fmt.Errorf("failed to delete blocks: %v", deletionFailures)
 	}

--- a/backupbackingimage/cleanup_test.go
+++ b/backupbackingimage/cleanup_test.go
@@ -1,0 +1,125 @@
+package backupbackingimage
+
+import (
+	"errors"
+	"io"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/longhorn/backupstore/common"
+)
+
+type cleanupTestDriver struct {
+	mu           sync.Mutex
+	removeCalls  []string
+	removeErrors map[string]error
+	active       int
+	maxActive    int
+}
+
+func (d *cleanupTestDriver) Kind() string              { return "cleanup-test" }
+func (d *cleanupTestDriver) GetURL() string            { return "cleanup-test://localhost" }
+func (d *cleanupTestDriver) FileExists(string) bool    { return false }
+func (d *cleanupTestDriver) FileSize(string) int64     { return -1 }
+func (d *cleanupTestDriver) FileTime(string) time.Time { return time.Time{} }
+func (d *cleanupTestDriver) Read(string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+func (d *cleanupTestDriver) Write(string, io.ReadSeeker) error { return nil }
+func (d *cleanupTestDriver) List(string) ([]string, error)     { return nil, nil }
+func (d *cleanupTestDriver) Upload(string, string) error       { return nil }
+func (d *cleanupTestDriver) Download(string, string) error     { return nil }
+
+func (d *cleanupTestDriver) Remove(path string) error {
+	d.mu.Lock()
+	d.removeCalls = append(d.removeCalls, path)
+	d.active++
+	if d.active > d.maxActive {
+		d.maxActive = d.active
+	}
+	err := d.removeErrors[path]
+	d.mu.Unlock()
+
+	time.Sleep(5 * time.Millisecond)
+
+	d.mu.Lock()
+	d.active--
+	d.mu.Unlock()
+	return err
+}
+
+type exactCleanupTestDriver struct {
+	*cleanupTestDriver
+
+	exactCalls int
+	exactPaths []string
+	exactErr   error
+}
+
+func (d *exactCleanupTestDriver) RemoveFiles(paths []string) error {
+	d.exactCalls++
+	d.exactPaths = append(d.exactPaths, paths...)
+	return d.exactErr
+}
+
+func TestCleanupBlocksUsesExactFileRemoverForSafeBlocks(t *testing.T) {
+	driver := &exactCleanupTestDriver{cleanupTestDriver: &cleanupTestDriver{removeErrors: map[string]error{}}}
+	blocks := map[string]*common.BlockInfo{
+		"delete-1":           {Checksum: "delete-1", Path: "blocks/delete-1.blk"},
+		"delete-2":           {Checksum: "delete-2", Path: "blocks/delete-2.blk"},
+		"referenced":         {Checksum: "referenced", Path: "blocks/referenced.blk", Refcount: 1},
+		"missing":            {Checksum: "missing"},
+		"referenced-missing": {Checksum: "referenced-missing", Refcount: 1},
+	}
+
+	if err := cleanupBlocks(logrus.New().WithField("test", true), driver, blocks); err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Strings(driver.exactPaths)
+	assert.Equal(t, []string{"blocks/delete-1.blk", "blocks/delete-2.blk"}, driver.exactPaths)
+	assert.Equal(t, 1, driver.exactCalls)
+	assert.Empty(t, driver.removeCalls, "the prefix-removing fallback must not be used")
+}
+
+func TestCleanupBlocksExactRemovalFailureIsReturned(t *testing.T) {
+	removeErr := errors.New("exact removal failed")
+	driver := &exactCleanupTestDriver{
+		cleanupTestDriver: &cleanupTestDriver{removeErrors: map[string]error{}},
+		exactErr:          removeErr,
+	}
+	blocks := map[string]*common.BlockInfo{
+		"delete":     {Checksum: "delete", Path: "blocks/delete.blk"},
+		"referenced": {Checksum: "referenced", Path: "blocks/referenced.blk", Refcount: 1},
+	}
+
+	err := cleanupBlocks(logrus.New().WithField("test", true), driver, blocks)
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("expected error %v, got %v", removeErr, err)
+	}
+	assert.Contains(t, err.Error(), "failed to delete backing image blocks")
+	assert.Equal(t, []string{"blocks/delete.blk"}, driver.exactPaths)
+	assert.Empty(t, driver.removeCalls)
+}
+
+func TestCleanupBlocksKeepsLegacyRemovalSerial(t *testing.T) {
+	driver := &cleanupTestDriver{removeErrors: map[string]error{}}
+	blocks := map[string]*common.BlockInfo{
+		"delete-1":   {Checksum: "delete-1", Path: "blocks/delete-1.blk"},
+		"delete-2":   {Checksum: "delete-2", Path: "blocks/delete-2.blk"},
+		"referenced": {Checksum: "referenced", Path: "blocks/referenced.blk", Refcount: 1},
+	}
+
+	if err := cleanupBlocks(logrus.New().WithField("test", true), driver, blocks); err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Strings(driver.removeCalls)
+	assert.Equal(t, []string{"blocks/delete-1.blk", "blocks/delete-2.blk"}, driver.removeCalls)
+	assert.Equal(t, 1, driver.maxActive)
+}

--- a/deltablock.go
+++ b/deltablock.go
@@ -1457,24 +1457,42 @@ func DeleteDeltaBlockBackup(backupURL string) (err error) {
 }
 
 func cleanupBlocks(driver BackupStoreDriver, blockMap map[string]*BlockInfo, volume string) error {
-	var deletionFailures []string
 	activeBlockCount := int64(0)
 	deletedBlockCount := int64(0)
-	for _, blk := range blockMap {
-		if isBlockSafeToDelete(blk) {
-			if err := driver.Remove(blk.path); err != nil {
-				deletionFailures = append(deletionFailures, blk.checksum)
-				continue
-			}
-			log.Debugf("Deleted block %v for volume %v", blk.checksum, volume)
-			deletedBlockCount++
-		} else if isBlockReferenced(blk) && isBlockPresent(blk) {
-			activeBlockCount++
-		}
-	}
 
-	if len(deletionFailures) > 0 {
-		return fmt.Errorf("failed to delete backup blocks: %v", deletionFailures)
+	if remover, ok := driver.(ExactFileRemover); ok {
+		if err := RemoveExactFiles(remover, func(yield func(string) bool) {
+			for _, blk := range blockMap {
+				if isBlockSafeToDelete(blk) {
+					deletedBlockCount++
+					if !yield(blk.path) {
+						return
+					}
+				} else if isBlockReferenced(blk) && isBlockPresent(blk) {
+					activeBlockCount++
+				}
+			}
+		}); err != nil {
+			return errors.Wrap(err, "failed to delete backup blocks")
+		}
+	} else {
+		var deletionFailures []string
+		for _, blk := range blockMap {
+			if isBlockSafeToDelete(blk) {
+				if err := driver.Remove(blk.path); err != nil {
+					deletionFailures = append(deletionFailures, blk.checksum)
+					continue
+				}
+				log.Debugf("Deleted block %v for volume %v", blk.checksum, volume)
+				deletedBlockCount++
+			} else if isBlockReferenced(blk) && isBlockPresent(blk) {
+				activeBlockCount++
+			}
+		}
+
+		if len(deletionFailures) > 0 {
+			return fmt.Errorf("failed to delete backup blocks: %v", deletionFailures)
+		}
 	}
 
 	log.Infof("Retained %v blocks for volume %v", activeBlockCount, volume)

--- a/deltablock_cleanup_test.go
+++ b/deltablock_cleanup_test.go
@@ -1,0 +1,191 @@
+package backupstore
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+type cleanupTestDriver struct {
+	mockStoreDriver
+
+	mu           sync.Mutex
+	removeCalls  []string
+	removeErrors map[string]error
+	active       int
+	maxActive    int
+	writeCalls   int
+}
+
+func newCleanupTestDriver(t *testing.T, volume *Volume) *cleanupTestDriver {
+	t.Helper()
+
+	driver := &cleanupTestDriver{
+		mockStoreDriver: mockStoreDriver{
+			fs:      afero.NewMemMapFs(),
+			destURL: "cleanup-test://localhost",
+		},
+		removeErrors: map[string]error{},
+	}
+
+	data, err := json.Marshal(volume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := driver.fs.MkdirAll(filepath.Dir(getVolumeFilePath(volume.Name)), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := afero.WriteFile(driver.fs, getVolumeFilePath(volume.Name), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return driver
+}
+
+func (d *cleanupTestDriver) Remove(path string) error {
+	d.mu.Lock()
+	d.removeCalls = append(d.removeCalls, path)
+	d.active++
+	if d.active > d.maxActive {
+		d.maxActive = d.active
+	}
+	err := d.removeErrors[path]
+	d.mu.Unlock()
+
+	// Make an accidental concurrent fallback observable while keeping this
+	// test fast. Drivers implementing only Remove historically run serially.
+	time.Sleep(5 * time.Millisecond)
+
+	d.mu.Lock()
+	d.active--
+	d.mu.Unlock()
+	return err
+}
+
+func (d *cleanupTestDriver) Write(dst string, rs io.ReadSeeker) error {
+	data, err := io.ReadAll(rs)
+	if err != nil {
+		return err
+	}
+
+	d.mu.Lock()
+	d.writeCalls++
+	d.mu.Unlock()
+
+	if err := d.fs.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	return afero.WriteFile(d.fs, dst, data, 0644)
+}
+
+func (d *cleanupTestDriver) calls() (removeCalls []string, maxActive, writeCalls int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.removeCalls...), d.maxActive, d.writeCalls
+}
+
+type exactCleanupTestDriver struct {
+	*cleanupTestDriver
+
+	exactCalls int
+	exactPaths []string
+	exactErr   error
+}
+
+func (d *exactCleanupTestDriver) RemoveFiles(paths []string) error {
+	d.exactCalls++
+	d.exactPaths = append(d.exactPaths, paths...)
+	return d.exactErr
+}
+
+func TestCleanupBlocksUsesExactFileRemoverForSafeBlocks(t *testing.T) {
+	volumeName := "cleanup-volume"
+	driver := &exactCleanupTestDriver{
+		cleanupTestDriver: newCleanupTestDriver(t, &Volume{Name: volumeName, BlockCount: 99}),
+	}
+	blocks := map[string]*BlockInfo{
+		"delete-1":           {checksum: "delete-1", path: "blocks/delete-1.blk"},
+		"delete-2":           {checksum: "delete-2", path: "blocks/delete-2.blk"},
+		"referenced":         {checksum: "referenced", path: "blocks/referenced.blk", refcount: 2},
+		"missing":            {checksum: "missing"},
+		"referenced-missing": {checksum: "referenced-missing", refcount: 1},
+	}
+
+	if err := cleanupBlocks(driver, blocks, volumeName); err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Strings(driver.exactPaths)
+	assert.Equal(t, []string{"blocks/delete-1.blk", "blocks/delete-2.blk"}, driver.exactPaths)
+	assert.Equal(t, 1, driver.exactCalls)
+	removeCalls, _, writeCalls := driver.calls()
+	assert.Empty(t, removeCalls, "the prefix-removing fallback must not be used")
+	assert.Equal(t, 1, writeCalls)
+
+	volume, err := loadVolume(driver, volumeName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, int64(1), volume.BlockCount)
+}
+
+func TestCleanupBlocksExactRemovalFailurePreservesBlockCount(t *testing.T) {
+	volumeName := "cleanup-volume"
+	removeErr := errors.New("exact removal failed")
+	driver := &exactCleanupTestDriver{
+		cleanupTestDriver: newCleanupTestDriver(t, &Volume{Name: volumeName, BlockCount: 99}),
+		exactErr:          removeErr,
+	}
+	blocks := map[string]*BlockInfo{
+		"delete":     {checksum: "delete", path: "blocks/delete.blk"},
+		"referenced": {checksum: "referenced", path: "blocks/referenced.blk", refcount: 1},
+	}
+
+	err := cleanupBlocks(driver, blocks, volumeName)
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("expected error %v, got %v", removeErr, err)
+	}
+	assert.Contains(t, err.Error(), "failed to delete backup blocks")
+	assert.Equal(t, []string{"blocks/delete.blk"}, driver.exactPaths)
+	removeCalls, _, writeCalls := driver.calls()
+	assert.Empty(t, removeCalls)
+	assert.Zero(t, writeCalls, "incomplete GC must not update volume metadata")
+
+	volume, loadErr := loadVolume(driver, volumeName)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	assert.Equal(t, int64(99), volume.BlockCount)
+}
+
+func TestCleanupBlocksKeepsLegacyRemovalSerialAndAttemptsEveryBlock(t *testing.T) {
+	volumeName := "cleanup-volume"
+	driver := newCleanupTestDriver(t, &Volume{Name: volumeName, BlockCount: 99})
+	driver.removeErrors["blocks/delete-2.blk"] = errors.New("remove failed")
+	blocks := map[string]*BlockInfo{
+		"delete-1":   {checksum: "delete-1", path: "blocks/delete-1.blk"},
+		"delete-2":   {checksum: "delete-2", path: "blocks/delete-2.blk"},
+		"delete-3":   {checksum: "delete-3", path: "blocks/delete-3.blk"},
+		"referenced": {checksum: "referenced", path: "blocks/referenced.blk", refcount: 1},
+	}
+
+	err := cleanupBlocks(driver, blocks, volumeName)
+	if err == nil {
+		t.Fatal("expected block removal error")
+	}
+	assert.Contains(t, err.Error(), "delete-2")
+
+	removeCalls, maxActive, writeCalls := driver.calls()
+	sort.Strings(removeCalls)
+	assert.Equal(t, []string{"blocks/delete-1.blk", "blocks/delete-2.blk", "blocks/delete-3.blk"}, removeCalls)
+	assert.Equal(t, 1, maxActive)
+	assert.Zero(t, writeCalls, "incomplete GC must not update volume metadata")
+}

--- a/exact_file_remover.go
+++ b/exact_file_remover.go
@@ -1,0 +1,59 @@
+package backupstore
+
+import (
+	"iter"
+
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	exactFileRemovalInitialCapacity   = 1024
+	exactFileRemovalBatchSize         = 64 * 1024
+	maxExactFileRemovalFailureSamples = 10
+)
+
+// ExactFileRemover is an optional extension of BackupStoreDriver for removing
+// a set of known files without first expanding each path as a prefix.
+//
+// Implementations must remove only the supplied paths, attempt every removal
+// before returning an aggregate error, bound any internal concurrency, and not
+// retain paths after returning. RemoveFiles does not imply use of a provider's
+// multi-object delete API.
+type ExactFileRemover interface {
+	RemoveFiles(paths []string) error
+}
+
+// RemoveExactFiles feeds paths to remover in bounded batches. It continues
+// after a batch error so every path is attempted, then returns a bounded error
+// summary. The iterator avoids materializing every GC candidate at once.
+func RemoveExactFiles(remover ExactFileRemover, paths iter.Seq[string]) error {
+	batch := make([]string, 0, exactFileRemovalInitialCapacity)
+	failureCount := 0
+	failureSamples := make([]error, 0, maxExactFileRemovalFailureSamples)
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if err := remover.RemoveFiles(batch); err != nil {
+			failureCount++
+			if len(failureSamples) < maxExactFileRemovalFailureSamples {
+				failureSamples = append(failureSamples, err)
+			}
+		}
+		batch = batch[:0]
+	}
+
+	for path := range paths {
+		batch = append(batch, path)
+		if len(batch) == exactFileRemovalBatchSize {
+			flush()
+		}
+	}
+	flush()
+
+	if failureCount > 0 {
+		return errors.Wrapf(errors.Join(failureSamples...), "failed to remove exact files in %d batches", failureCount)
+	}
+	return nil
+}

--- a/exact_file_remover_test.go
+++ b/exact_file_remover_test.go
@@ -1,0 +1,72 @@
+package backupstore
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type batchingTestRemover struct {
+	batchSizes []int
+	failCalls  map[int]error
+}
+
+func (r *batchingTestRemover) RemoveFiles(paths []string) error {
+	call := len(r.batchSizes)
+	r.batchSizes = append(r.batchSizes, len(paths))
+	return r.failCalls[call]
+}
+
+func TestRemoveExactFilesBoundsBatchesAndAttemptsAllPaths(t *testing.T) {
+	firstErr := errors.New("first batch failed")
+	remover := &batchingTestRemover{failCalls: map[int]error{0: firstErr}}
+	total := exactFileRemovalBatchSize + 3
+
+	err := RemoveExactFiles(remover, func(yield func(string) bool) {
+		for i := 0; i < total; i++ {
+			if !yield("block.blk") {
+				return
+			}
+		}
+	})
+	if err == nil || !strings.Contains(err.Error(), firstErr.Error()) {
+		t.Fatalf("expected the first batch error, got %v", err)
+	}
+	if len(remover.batchSizes) != 2 || remover.batchSizes[0] != exactFileRemovalBatchSize || remover.batchSizes[1] != 3 {
+		t.Fatalf("unexpected batches: %v", remover.batchSizes)
+	}
+}
+
+func TestRemoveExactFilesBoundsFailureDetails(t *testing.T) {
+	batchCount := maxExactFileRemovalFailureSamples + 2
+	failures := make(map[int]error, batchCount)
+	for i := 0; i < batchCount; i++ {
+		failures[i] = fmt.Errorf("batch-%d failed", i)
+	}
+	remover := &batchingTestRemover{failCalls: failures}
+
+	err := RemoveExactFiles(remover, func(yield func(string) bool) {
+		for i := 0; i < batchCount*exactFileRemovalBatchSize; i++ {
+			if !yield("block.blk") {
+				return
+			}
+		}
+	})
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("in %d batches", batchCount)) {
+		t.Fatalf("unexpected aggregate error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "batch-9 failed") || strings.Contains(err.Error(), "batch-10 failed") {
+		t.Fatalf("expected exactly the first %d failure details, got %v", maxExactFileRemovalFailureSamples, err)
+	}
+}
+
+func TestRemoveExactFilesSkipsEmptyInput(t *testing.T) {
+	remover := &batchingTestRemover{}
+	if err := RemoveExactFiles(remover, func(func(string) bool) {}); err != nil {
+		t.Fatal(err)
+	}
+	if len(remover.batchSizes) != 0 {
+		t.Fatalf("expected no removal calls, got %v", remover.batchSizes)
+	}
+}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -7,10 +7,13 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/longhorn/backupstore"
@@ -28,6 +31,10 @@ type BackupStoreDriver struct {
 
 const (
 	KIND = "s3"
+
+	// Deletion locks can overlap, so keep each operation's pressure conservative.
+	maxConcurrentExactFileRemovals = 8
+	maxRemovalFailureSamples       = 10
 )
 
 func init() {
@@ -167,6 +174,74 @@ func (s *BackupStoreDriver) FileTime(filePath string) time.Time {
 func (s *BackupStoreDriver) Remove(path string) error {
 	ctx := context.Background()
 	return s.service.DeleteObjects(ctx, s.updatePath(path))
+}
+
+// RemoveFiles removes exact object keys using bounded concurrent DeleteObject
+// requests. It intentionally does not use the S3 multi-object delete API,
+// which is unsupported by some S3-compatible providers such as GCS.
+func (s *BackupStoreDriver) RemoveFiles(paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	ctx := context.Background()
+	svc, err := s.service.newInstance(ctx, false)
+	if err != nil {
+		return errors.Wrap(err, "failed to get a new s3 client instance before removing exact objects")
+	}
+	defer s.service.Close()
+
+	return removeFiles(ctx, svc, s.service.Bucket, paths, s.updatePath, maxConcurrentExactFileRemovals)
+}
+
+func removeFiles(ctx context.Context, svc objectDeleteAPI, bucket string, paths []string,
+	updatePath func(string) string, concurrentLimit int) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	if concurrentLimit < 1 {
+		return fmt.Errorf("exact file removal concurrency must be greater than zero")
+	}
+
+	workerCount := min(concurrentLimit, len(paths))
+	jobs := make(chan string, workerCount)
+
+	var (
+		wg             sync.WaitGroup
+		failureLock    sync.Mutex
+		failureCount   int
+		failureSamples = make([]string, 0, min(maxRemovalFailureSamples, len(paths)))
+	)
+
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for path := range jobs {
+				key := updatePath(path)
+				if err := deleteObject(ctx, svc, bucket, key); err != nil {
+					failureLock.Lock()
+					failureCount++
+					if len(failureSamples) < maxRemovalFailureSamples {
+						failureSamples = append(failureSamples, fmt.Sprintf("%s: %v", path, err))
+					}
+					failureLock.Unlock()
+				}
+			}
+		}()
+	}
+
+	for _, path := range paths {
+		jobs <- path
+	}
+	close(jobs)
+	wg.Wait()
+
+	if failureCount > 0 {
+		sort.Strings(failureSamples)
+		return fmt.Errorf("failed to delete %d exact objects (sample errors: %v)", failureCount, failureSamples)
+	}
+	return nil
 }
 
 func (s *BackupStoreDriver) Read(src string) (io.ReadCloser, error) {

--- a/s3/s3_remove_test.go
+++ b/s3/s3_remove_test.go
@@ -1,0 +1,267 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+)
+
+type fakeObjectDeleteClient struct {
+	mu        sync.Mutex
+	calls     []string
+	active    int
+	maxActive int
+	delay     time.Duration
+	failures  map[string]error
+}
+
+func (f *fakeObjectDeleteClient) DeleteObject(ctx context.Context, input *awss3.DeleteObjectInput,
+	_ ...func(*awss3.Options)) (*awss3.DeleteObjectOutput, error) {
+	key := aws.ToString(input.Key)
+
+	f.mu.Lock()
+	f.calls = append(f.calls, key)
+	f.active++
+	if f.active > f.maxActive {
+		f.maxActive = f.active
+	}
+	f.mu.Unlock()
+
+	if f.delay > 0 {
+		select {
+		case <-ctx.Done():
+		case <-time.After(f.delay):
+		}
+	}
+
+	f.mu.Lock()
+	f.active--
+	err := f.failures[key]
+	f.mu.Unlock()
+
+	return &awss3.DeleteObjectOutput{}, err
+}
+
+func (f *fakeObjectDeleteClient) snapshot() ([]string, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	calls := append([]string(nil), f.calls...)
+	return calls, f.maxActive
+}
+
+func TestRemoveFilesUsesBoundedConcurrency(t *testing.T) {
+	const concurrency = 4
+	paths := make([]string, 32)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("blocks/%02d.blk", i)
+	}
+	client := &fakeObjectDeleteClient{delay: 10 * time.Millisecond}
+
+	err := removeFiles(context.Background(), client, "bucket", paths,
+		func(path string) string { return "prefix/" + path }, concurrency)
+	if err != nil {
+		t.Fatalf("removeFiles failed: %v", err)
+	}
+
+	calls, maxActive := client.snapshot()
+	if maxActive != concurrency {
+		t.Fatalf("expected concurrency to reach %d, got %d", concurrency, maxActive)
+	}
+	if len(calls) != len(paths) {
+		t.Fatalf("expected %d deletes, got %d", len(paths), len(calls))
+	}
+	sort.Strings(calls)
+	for i, path := range paths {
+		expected := "prefix/" + path
+		if calls[i] != expected {
+			t.Fatalf("expected call %q, got %q", expected, calls[i])
+		}
+	}
+}
+
+func TestRemoveFilesAttemptsEveryPathAndAggregatesErrors(t *testing.T) {
+	paths := []string{"a.blk", "b.blk", "c.blk", "d.blk"}
+	client := &fakeObjectDeleteClient{
+		failures: map[string]error{
+			"a.blk": errors.New("first failure"),
+			"c.blk": errors.New("second failure"),
+		},
+	}
+
+	err := removeFiles(context.Background(), client, "bucket", paths, func(path string) string { return path }, 2)
+	if err == nil {
+		t.Fatal("expected removeFiles to return an aggregate error")
+	}
+	if !strings.Contains(err.Error(), "failed to delete 2 exact objects") ||
+		!strings.Contains(err.Error(), "a.blk") || !strings.Contains(err.Error(), "c.blk") {
+		t.Fatalf("unexpected aggregate error: %v", err)
+	}
+
+	calls, maxActive := client.snapshot()
+	if len(calls) != len(paths) {
+		t.Fatalf("expected every path to be attempted, got %v", calls)
+	}
+	if maxActive > 2 {
+		t.Fatalf("expected at most 2 concurrent deletes, got %d", maxActive)
+	}
+}
+
+func TestRemoveFilesBoundsFailureDetails(t *testing.T) {
+	paths := make([]string, maxRemovalFailureSamples+5)
+	failures := make(map[string]error, len(paths))
+	for i := range paths {
+		paths[i] = fmt.Sprintf("%02d.blk", i)
+		failures[paths[i]] = errors.New("delete failed")
+	}
+	client := &fakeObjectDeleteClient{failures: failures}
+
+	err := removeFiles(context.Background(), client, "bucket", paths, func(path string) string { return path }, 3)
+	if err == nil {
+		t.Fatal("expected removeFiles to return an aggregate error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("failed to delete %d exact objects", len(paths))) {
+		t.Fatalf("unexpected aggregate error: %v", err)
+	}
+	if details := strings.Count(err.Error(), "delete failed"); details != maxRemovalFailureSamples {
+		t.Fatalf("expected %d sampled failure details, got %d: %v", maxRemovalFailureSamples, details, err)
+	}
+}
+
+func TestRemoveFilesRejectsInvalidConcurrency(t *testing.T) {
+	client := &fakeObjectDeleteClient{}
+	err := removeFiles(context.Background(), client, "bucket", []string{"block.blk"},
+		func(path string) string { return path }, 0)
+	if err == nil || !strings.Contains(err.Error(), "concurrency") {
+		t.Fatalf("expected an invalid concurrency error, got %v", err)
+	}
+	if calls, _ := client.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no delete attempts, got %v", calls)
+	}
+}
+
+func TestDeleteObjectTreatsMissingKeyAsSuccess(t *testing.T) {
+	client := &fakeObjectDeleteClient{
+		failures: map[string]error{
+			"missing.blk": &smithy.GenericAPIError{Code: "NoSuchKey", Message: "not found"},
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := deleteObject(context.Background(), client, "bucket", "missing.blk"); err != nil {
+			t.Fatalf("expected a repeated missing-key delete to be idempotent, got %v", err)
+		}
+	}
+}
+
+func TestDeleteObjectDoesNotIgnoreMissingBucket(t *testing.T) {
+	client := &fakeObjectDeleteClient{
+		failures: map[string]error{
+			"block.blk": &smithy.GenericAPIError{Code: "NoSuchBucket", Message: "not found"},
+		},
+	}
+
+	err := deleteObject(context.Background(), client, "bucket", "block.blk")
+	if err == nil || !strings.Contains(err.Error(), "NoSuchBucket") {
+		t.Fatalf("expected the missing bucket error to be preserved, got %v", err)
+	}
+}
+
+func TestRemoveFilesIssuesOnlyExactDeleteRequests(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		requests []recordedRequest
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		mu.Lock()
+		requests = append(requests, recordedRequest{method: r.Method, path: r.URL.Path, query: r.URL.RawQuery})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	driver := &BackupStoreDriver{
+		path:    "backup-root",
+		service: newTestService(t, server.URL),
+	}
+	paths := []string{
+		"blocks/aa/bb/first.blk",
+		"blocks/aa/bb/second.blk",
+		"blocks/cc/dd/third.blk",
+	}
+
+	if err := driver.RemoveFiles(paths); err != nil {
+		t.Fatalf("RemoveFiles failed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requests) != len(paths) {
+		t.Fatalf("expected exactly %d requests, got %d: %+v", len(paths), len(requests), requests)
+	}
+	expected := map[string]bool{}
+	for _, path := range paths {
+		expected["/test-bucket/backup-root/"+path] = true
+	}
+	for _, request := range requests {
+		if request.method != http.MethodDelete {
+			t.Fatalf("expected only DELETE requests, got %+v", request)
+		}
+		if request.query != "x-id=DeleteObject" {
+			t.Fatalf("expected only the DeleteObject operation query, got %+v", request)
+		}
+		if !expected[request.path] {
+			t.Fatalf("unexpected object path %q", request.path)
+		}
+		delete(expected, request.path)
+	}
+	if len(expected) != 0 {
+		t.Fatalf("missing exact delete requests: %v", expected)
+	}
+}
+
+type delayedObjectDeleteClient struct {
+	delay time.Duration
+}
+
+func (d delayedObjectDeleteClient) DeleteObject(ctx context.Context, _ *awss3.DeleteObjectInput,
+	_ ...func(*awss3.Options)) (*awss3.DeleteObjectOutput, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(d.delay):
+		return &awss3.DeleteObjectOutput{}, nil
+	}
+}
+
+func BenchmarkRemoveFiles(b *testing.B) {
+	paths := make([]string, 100)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("blocks/%03d.blk", i)
+	}
+	client := delayedObjectDeleteClient{delay: time.Millisecond}
+
+	for _, concurrency := range []int{1, maxConcurrentExactFileRemovals} {
+		b.Run(fmt.Sprintf("concurrency-%d", concurrency), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := removeFiles(context.Background(), client, "bucket", paths,
+					func(path string) string { return path }, concurrency); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/s3/s3_service.go
+++ b/s3/s3_service.go
@@ -30,6 +30,10 @@ type service struct {
 	Client *http.Client
 }
 
+type objectDeleteAPI interface {
+	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
 const (
 	VirtualHostedStyle = "VIRTUAL_HOSTED_STYLE"
 
@@ -359,4 +363,21 @@ func (s *service) DeleteObjects(ctx context.Context, key string) error {
 	}
 
 	return nil
+}
+
+func deleteObject(ctx context.Context, svc objectDeleteAPI, bucket, key string) error {
+	_, err := svc.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err == nil {
+		return nil
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchKey" {
+		return nil
+	}
+
+	return errors.Wrapf(parseAwsError(err), "failed to delete exact object %v", key)
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#8060

#### What this PR does / why we need it:

Block GC already knows the exact object path for every unreferenced block. However, the S3 driver's existing `Remove` method treats each path as a prefix: it issues `ListObjectsV2`, creates another SDK client, and then calls `DeleteObject`. GC repeats that sequence serially for every unused block.

This PR adds an optional `ExactFileRemover` capability and uses it for volume-backup and backing-image block GC:

- Feed known block paths lazily in batches of at most 65,536, bounding additional path memory to roughly 1 MiB of string descriptors.
- Create one S3 SDK client per batch and share it across eight bounded workers.
- Issue individual, exact-key `DeleteObject` requests without a preceding LIST.
- Attempt every key and every batch before returning a bounded aggregate error.
- Treat `NoSuchKey` as an idempotent success.
- Preserve the current serial `Remove` fallback for all drivers that do not opt in.
- Keep volume `BlockCount` unchanged if any deletion fails.

For `N` unused S3 blocks, this changes the deletion phase from approximately `N` prefix LISTs plus `N` serial DELETEs to `N` bounded-concurrent DELETEs. It does not change reference discovery or lock safety.

Synthetic benchmark: 100 exact deletions with 1 ms fake request latency, Apple M1 Max, three iterations:

| Path | Time/op | Allocated/op | Allocs/op |
|---|---:|---:|---:|
| 1 worker | 113.72 ms | 43,080 B | 709 |
| 8 workers | 14.82 ms | 45,576 B | 721 |

This is about 7.7x lower elapsed time in the latency-bound deletion phase. The HTTP regression test separately verifies exactly one DELETE per path and no LIST or multi-object-delete request.

#### Special notes for your reviewer:

This deliberately does **not** use the S3 Multi-Object Delete API. Longhorn removed that path in backupstore#41 because Google Cloud Storage's S3 interoperability rejected it (longhorn/longhorn#1404). The implementation uses concurrent individual `DeleteObject` calls instead.

This is independent of and complementary to backupstore#313:

- #313 reduces the sharded block-enumeration LIST count.
- This PR removes the redundant per-deleted-block LIST and parallelizes exact deletion.

Deletion locks of the same type can overlap. The limit is therefore eight requests per GC operation, not a global rate limit. Coalescing duplicate GCs, changing lock scope, and optimizing retained-manifest scanning remain separate work.

Regression coverage includes:

- exact-remover selection and serial-driver fallback
- safe-path filtering for volume and backing-image GC
- volume metadata preservation after partial failure
- bounded concurrency and bounded queues
- all-key/all-batch attempt behavior after errors
- bounded aggregate error details
- missing-key idempotency without hiding `NoSuchBucket`
- exact S3 request method/path/count
- 65,536-key batch-memory bound

Validation:

- Focused root cleanup tests with `-race`: pass
- `go test -race ./backupbackingimage`: pass
- `go test -race ./s3`: pass
- Linux cross-compilation of `./...`: pass
- Linux `go vet ./...`: pass
- Linux `golangci-lint run ./...`: 0 issues

The repository's current `scripts/test` omits root-package tests, so the new root cleanup tests were invoked explicitly. The full pre-existing root suite also has the unrelated `TestInspectBackup` failure described by #313; this change does not modify that path.

#### Additional documentation or context

Historical review precedent already recommended a fixed worker pool and noted that `DeleteObjects` could benefit from parallel deletion: backupstore#63.